### PR TITLE
feat: allow bots on all symbols and show separate trade times

### DIFF
--- a/gui/bot_add_dialog.py
+++ b/gui/bot_add_dialog.py
@@ -5,6 +5,7 @@ from PyQt6.QtWidgets import (
     QDialogButtonBox,
     QLabel,
     QLineEdit,
+    QMessageBox,
 )
 
 ALL_SYMBOLS_LABEL = "Все валютные пары"
@@ -28,6 +29,15 @@ class AddBotDialog(QDialog):
 
         layout = QVBoxLayout()
 
+        # Сначала выбор алгоритма
+        layout.addWidget(QLabel("Алгоритм:"))
+        self.strategy_combo = QComboBox()
+        for key in self.available_strategies.keys():
+            label = self.strategy_labels.get(key, key)
+            self.strategy_combo.addItem(label, userData=key)
+        layout.addWidget(self.strategy_combo)
+        self.strategy_combo.currentIndexChanged.connect(self.on_strategy_change)
+
         # Поиск валют
         layout.addWidget(QLabel("Поиск валютной пары:"))
         self.search_edit = QLineEdit()
@@ -47,14 +57,6 @@ class AddBotDialog(QDialog):
         self.tf_combo.setCurrentText("M1")
         layout.addWidget(self.tf_combo)
 
-        # Стратегии
-        layout.addWidget(QLabel("Алгоритм:"))
-        self.strategy_combo = QComboBox()
-        for key in self.available_strategies.keys():
-            label = self.strategy_labels.get(key, key)
-            self.strategy_combo.addItem(label, userData=key)
-        layout.addWidget(self.strategy_combo)
-
         # Кнопки
         buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -64,6 +66,7 @@ class AddBotDialog(QDialog):
         layout.addWidget(buttons)
 
         self.setLayout(layout)
+        self.on_strategy_change()
 
     def filter_symbols(self, text: str):
         self.symbol_combo.clear()
@@ -80,6 +83,25 @@ class AddBotDialog(QDialog):
             if t in s.upper() or t in s_no_slash:
                 filtered.append(s)
         self.symbol_combo.addItems(filtered)
+        self.on_strategy_change()
+
+    def on_strategy_change(self, *_):
+        key = self.selected_strategy
+        is_martingale = key == "martingale"
+
+        # disable "all" options for Martingale
+        sym_item = self.symbol_combo.model().item(0)
+        tf_item = self.tf_combo.model().item(0)
+        if sym_item:
+            sym_item.setEnabled(not is_martingale)
+        if tf_item:
+            tf_item.setEnabled(not is_martingale)
+
+        if is_martingale:
+            if self.symbol_combo.currentIndex() == 0 and self.symbol_combo.count() > 1:
+                self.symbol_combo.setCurrentIndex(1)
+            if self.tf_combo.currentIndex() == 0 and self.tf_combo.count() > 1:
+                self.tf_combo.setCurrentIndex(1)
 
     @property
     def selected_symbol(self):
@@ -95,3 +117,19 @@ class AddBotDialog(QDialog):
 
     def get_result(self):
         return self.selected_symbol, self.selected_strategy
+
+    def accept(self):
+        if (
+            self.selected_strategy == "martingale"
+            and (
+                self.selected_symbol == ALL_SYMBOLS_LABEL
+                or self.selected_timeframe == ALL_TF_LABEL
+            )
+        ):
+            QMessageBox.warning(
+                self,
+                "Ошибка",
+                "Стратегия 'Мартингейл' работает только с одной валютной парой и таймфреймом.",
+            )
+            return
+        super().accept()

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -198,15 +198,17 @@ class MainWindow(QWidget):
 
         # === Таблица результатов сделок ===
         self.trades_table = QTableWidget(self)
-        self.trades_table.setColumnCount(9)
+        self.trades_table.setColumnCount(11)
         self.trades_table.setHorizontalHeaderLabels(
             [
-                "Время",
+                "Время сигнала",
+                "Время ставки",
                 "Индикатор",
                 "Валютная пара",
                 "ТФ",
                 "Направление",
                 "Ставка",
+                "Время",
                 "Процент",
                 "P/L",
                 "Счет",
@@ -214,7 +216,7 @@ class MainWindow(QWidget):
         )
         hdr = self.trades_table.horizontalHeader()
         hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
-        hdr.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        hdr.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
         hdr.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
         hdr.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
         hdr.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)
@@ -222,6 +224,8 @@ class MainWindow(QWidget):
         hdr.setSectionResizeMode(6, QHeaderView.ResizeMode.ResizeToContents)
         hdr.setSectionResizeMode(7, QHeaderView.ResizeMode.ResizeToContents)
         hdr.setSectionResizeMode(8, QHeaderView.ResizeMode.ResizeToContents)
+        hdr.setSectionResizeMode(9, QHeaderView.ResizeMode.ResizeToContents)
+        hdr.setSectionResizeMode(10, QHeaderView.ResizeMode.ResizeToContents)
         self.trades_table.setAlternatingRowColors(True)
         # self.trades_table.setSortingEnabled(True)
 
@@ -597,6 +601,7 @@ class MainWindow(QWidget):
         self,
         *,
         trade_id: str,
+        signal_at: str,
         placed_at: str,
         symbol: str,
         timeframe: str,
@@ -611,7 +616,8 @@ class MainWindow(QWidget):
     ):
         """
         Добавляет строку «ожидание результата».
-        Колонки: Время | Индикатор | Пара | ТФ | Направление | Ставка | % | P/L | Счет
+        Колонки: Время сигнала | Время ставки | Индикатор | Пара | ТФ |
+                  Направление | Ставка | Время | % | P/L | Счет
         В P/L показываем обратный отсчёт, синхронизированный по expected_end_ts.
         """
         from time import time as _now
@@ -642,21 +648,24 @@ class MainWindow(QWidget):
             left_now = max(0.0, expected_end_ts - _now())
             account_txt = account_mode or ("ДЕМО" if self.is_demo else "РЕАЛ")
             ccy = self.account_currency
+            duration_txt = f"{int(round(float(wait_seconds) / 60))} мин"
 
             vals = [
-                placed_at,  # 0 Время
-                (indicator or "-"),  # 1 Индикатор
-                symbol,  # 2 Пара
-                timeframe,  # 3 ТФ
-                dir_text,  # 4 Направление
-                format_money(stake, ccy),  # 5 Ставка
-                f"{percent}%",  # 6 %
-                f"Ожидание ({_fmt_left(left_now)})",  # 7 P/L
-                account_txt,  # 8 Счёт
+                signal_at,  # 0 Время сигнала
+                placed_at,  # 1 Время ставки
+                (indicator or "-"),  # 2 Индикатор
+                symbol,  # 3 Пара
+                timeframe,  # 4 ТФ
+                dir_text,  # 5 Направление
+                format_money(stake, ccy),  # 6 Ставка
+                duration_txt,  # 7 Время
+                f"{percent}%",  # 8 %
+                f"Ожидание ({_fmt_left(left_now)})",  # 9 P/L
+                account_txt,  # 10 Счёт
             ]
             for col, v in enumerate(vals):
                 it = QTableWidgetItem(str(v))
-                if col in (4, 7):  # выравниваем Направление и P/L по центру
+                if col in (5, 9):  # выравниваем Направление и P/L по центру
                     it.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
                 self.trades_table.setItem(row, col, it)
 
@@ -675,7 +684,7 @@ class MainWindow(QWidget):
                 if row >= self.trades_table.rowCount():
                     timer.stop()
                     return
-                item = self.trades_table.item(row, 7)  # P/L
+                item = self.trades_table.item(row, 9)  # P/L
                 if item:
                     item.setText(f"Ожидание ({_fmt_left(left)})")
                 if left <= 0:
@@ -703,8 +712,10 @@ class MainWindow(QWidget):
                 "direction": int(direction),
                 "stake": float(stake),
                 "percent": int(percent),
+                "signal_at": signal_at,
                 "placed_at": placed_at,
                 "account_mode": account_mode or ("ДЕМО" if self.is_demo else "РЕАЛ"),
+                "wait_seconds": float(wait_seconds),
             }
 
             if was_sorting:
@@ -717,6 +728,7 @@ class MainWindow(QWidget):
         self,
         *,
         trade_id: str | None = None,
+        signal_at: str,
         placed_at: str,
         symbol: str,
         timeframe: str,
@@ -733,7 +745,7 @@ class MainWindow(QWidget):
         Красим строку по результату.
         """
 
-        def _fill_row(row: int, indicator_value: str):
+        def _fill_row(row: int, indicator_value: str, sig_time: str, place_time: str, duration_txt: str):
             dir_text = "ВВЕРХ" if int(direction) == 1 else "ВНИЗ"
             account_txt = account_mode or ("ДЕМО" if self.is_demo else "РЕАЛ")
             ccy = self.account_currency
@@ -745,19 +757,21 @@ class MainWindow(QWidget):
                 return "+" + txt if p > 0 else txt
 
             vals = [
-                placed_at,  # 0 Время
-                indicator_value,  # 1 Индикатор
-                symbol,  # 2 Пара
-                timeframe,  # 3 ТФ
-                dir_text,  # 4 Направление
-                format_money(stake, ccy),  # 5 Ставка
-                f"{percent}%",  # 6 %
-                fmt_pl(profit),  # 7 P/L
-                account_txt,  # 8 Счёт
+                sig_time,  # 0 Время сигнала
+                place_time,  # 1 Время ставки
+                indicator_value,  # 2 Индикатор
+                symbol,  # 3 Пара
+                timeframe,  # 4 ТФ
+                dir_text,  # 5 Направление
+                format_money(stake, ccy),  # 6 Ставка
+                duration_txt,  # 7 Время
+                f"{percent}%",  # 8 %
+                fmt_pl(profit),  # 9 P/L
+                account_txt,  # 10 Счёт
             ]
             for col, v in enumerate(vals):
                 it = QTableWidgetItem(str(v))
-                if col in (4, 7):
+                if col in (5, 9):
                     it.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
                 self.trades_table.setItem(row, col, it)
 
@@ -780,6 +794,9 @@ class MainWindow(QWidget):
 
             row_to_update = None
             indicator_value = indicator or "-"
+            sig_time = signal_at
+            place_time = placed_at
+            duration_txt = ""
 
             if trade_id and trade_id in self.pending_trades:
                 info = self.pending_trades.pop(trade_id, {})
@@ -794,12 +811,15 @@ class MainWindow(QWidget):
                     row_to_update = row
                     # если при pending уже знали индикатор — используем его
                     indicator_value = info.get("indicator", indicator_value)
+                    sig_time = info.get("signal_at", sig_time)
+                    place_time = info.get("placed_at", place_time)
+                    duration_txt = f"{int(round(info.get('wait_seconds', 0.0) / 60))} мин"
 
             if row_to_update is None:
                 row_to_update = 0
                 self.trades_table.insertRow(row_to_update)
 
-            _fill_row(row_to_update, indicator_value)
+            _fill_row(row_to_update, indicator_value, sig_time, place_time, duration_txt)
 
             if was_sorting:
                 self.trades_table.setSortingEnabled(True)
@@ -987,6 +1007,7 @@ class MainWindow(QWidget):
         self,
         *,
         trade_id,
+        signal_at,
         symbol,
         timeframe,
         placed_at,
@@ -1000,6 +1021,7 @@ class MainWindow(QWidget):
     ):
         self.add_trade_pending(
             trade_id=trade_id,
+            signal_at=signal_at,
             placed_at=placed_at,
             symbol=symbol,
             timeframe=timeframe,
@@ -1016,6 +1038,7 @@ class MainWindow(QWidget):
         self,
         *,
         trade_id,
+        signal_at,
         symbol,
         timeframe,
         placed_at,
@@ -1029,6 +1052,7 @@ class MainWindow(QWidget):
     ):
         self.add_trade_result(
             trade_id=trade_id,
+            signal_at=signal_at,
             placed_at=placed_at,
             symbol=symbol,
             timeframe=timeframe,

--- a/gui/settings_martingale.py
+++ b/gui/settings_martingale.py
@@ -51,10 +51,6 @@ class MartingaleSettingsDialog(QDialog):
         self.min_percent.setRange(0, 100)
         self.min_percent.setValue(self.params.get("min_percent", 70))
 
-        self.wait_on_low_percent = QSpinBox()
-        self.wait_on_low_percent.setRange(0, 60)
-        self.wait_on_low_percent.setValue(self.params.get("wait_on_low_percent", 1))
-
         form = QFormLayout()
         form.addRow("Базовая ставка", self.base_investment)
         form.addRow("Время экспирации (мин)", self.minutes)
@@ -63,7 +59,6 @@ class MartingaleSettingsDialog(QDialog):
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Коэффициент", self.coefficient)
         form.addRow("Мин. процент", self.min_percent)
-        form.addRow("Ожид. при низком % (с)", self.wait_on_low_percent)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -90,5 +85,4 @@ class MartingaleSettingsDialog(QDialog):
             "min_balance": self.min_balance.value(),
             "coefficient": self.coefficient.value(),
             "min_percent": self.min_percent.value(),
-            "wait_on_low_percent": self.wait_on_low_percent.value(),
         }

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -44,19 +44,18 @@ class StrategyControlDialog(QDialog):
             self.main.strategy_label(bot.strategy_kwargs.get("strategy_key", ""))
         )
         self.lbl_symbol = QLabel(bot.strategy_kwargs.get("symbol", ""))
-        self.lbl_status = QLabel("Статус: —")
-        self.lbl_ccy = QLabel("Валюта счёта: —")
-        for w in (self.lbl_strategy, self.lbl_symbol, self.lbl_status, self.lbl_ccy):
+        self.lbl_timeframe = QLabel(bot.strategy_kwargs.get("timeframe", ""))
+        for w in (self.lbl_strategy, self.lbl_symbol, self.lbl_timeframe):
             w.setStyleSheet("font-weight: 600;")
         hh.addWidget(QLabel("Стратегия:"))
         hh.addWidget(self.lbl_strategy)
         hh.addSpacing(12)
         hh.addWidget(QLabel("Символ:"))
         hh.addWidget(self.lbl_symbol)
-        hh.addStretch(1)
-        hh.addWidget(self.lbl_status)
         hh.addSpacing(12)
-        hh.addWidget(self.lbl_ccy)
+        hh.addWidget(QLabel("ТФ:"))
+        hh.addWidget(self.lbl_timeframe)
+        hh.addStretch(1)
 
         # ---------- ЛОГ (слева) ----------
         self.log_edit = QTextEdit()
@@ -72,35 +71,35 @@ class StrategyControlDialog(QDialog):
 
         # ---------- ТАБЛИЦА СДЕЛОК (справа) ----------
         self.trades_table = QTableWidget(self)
-        self.trades_table.setColumnCount(9)
+        self.trades_table.setColumnCount(11)
         self.trades_table.setHorizontalHeaderLabels(
             [
-                "Время",  # 0
-                "Пара",  # 1
-                "ТФ",  # 2
-                "Индикатор",  # 3  (если не прилетит — ставим "—")
-                "Направление",  # 4
-                "Ставка",  # 5
-                "Процент",  # 6
-                "P/L",  # 7
-                "Счёт",  # 8
+                "Время сигнала",  # 0
+                "Время ставки",  # 1
+                "Пара",  # 2
+                "ТФ",  # 3
+                "Индикатор",  # 4  (если не прилетит — ставим "—")
+                "Направление",  # 5
+                "Ставка",  # 6
+                "Время",  # 7
+                "Процент",  # 8
+                "P/L",  # 9
+                "Счёт",  # 10
             ]
         )
         hdr = self.trades_table.horizontalHeader()
         # PyQt6: используем QHeaderView.ResizeMode.*
-        hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)  # Время
-        hdr.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)  # Пара
-        hdr.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)  # ТФ
-        hdr.setSectionResizeMode(
-            3, QHeaderView.ResizeMode.ResizeToContents
-        )  # Индикатор
-        hdr.setSectionResizeMode(
-            4, QHeaderView.ResizeMode.ResizeToContents
-        )  # Направление
-        hdr.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)  # Ставка
-        hdr.setSectionResizeMode(6, QHeaderView.ResizeMode.ResizeToContents)  # %
-        hdr.setSectionResizeMode(7, QHeaderView.ResizeMode.ResizeToContents)  # P/L
-        hdr.setSectionResizeMode(8, QHeaderView.ResizeMode.ResizeToContents)  # Счёт
+        hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)  # Время сигнала
+        hdr.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)  # Время ставки
+        hdr.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)  # Пара
+        hdr.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)  # ТФ
+        hdr.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)  # Индикатор
+        hdr.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)  # Направление
+        hdr.setSectionResizeMode(6, QHeaderView.ResizeMode.ResizeToContents)  # Ставка
+        hdr.setSectionResizeMode(7, QHeaderView.ResizeMode.ResizeToContents)  # Время
+        hdr.setSectionResizeMode(8, QHeaderView.ResizeMode.ResizeToContents)  # %
+        hdr.setSectionResizeMode(9, QHeaderView.ResizeMode.ResizeToContents)  # P/L
+        hdr.setSectionResizeMode(10, QHeaderView.ResizeMode.ResizeToContents)  # Счёт
         self.trades_table.setAlternatingRowColors(True)
         self.trades_table.setSortingEnabled(True)
 
@@ -145,12 +144,6 @@ class StrategyControlDialog(QDialog):
         self.min_percent = QSpinBox()
         self.min_percent.setRange(0, 100)
         self.min_percent.setValue(int(getv("min_percent", 70)))
-        self.wait_on_low_percent = QSpinBox()
-        self.wait_on_low_percent.setRange(0, 60)
-        self.wait_on_low_percent.setValue(int(getv("wait_on_low_percent", 1)))
-        self.signal_timeout_sec = QSpinBox()
-        self.signal_timeout_sec.setRange(1, 24 * 3600)
-        self.signal_timeout_sec.setValue(int(getv("signal_timeout_sec", 3600)))
 
         form.addRow("Базовая ставка", self.base_investment)
         form.addRow("Время сделки (мин)", self.minutes)
@@ -159,8 +152,6 @@ class StrategyControlDialog(QDialog):
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Коэффициент", self.coefficient)
         form.addRow("Мин. процент", self.min_percent)
-        form.addRow("Ожидание при низком % (с)", self.wait_on_low_percent)
-        form.addRow("Таймаут ожидания сигнала (с)", self.signal_timeout_sec)
 
         # Кнопка «Сохранить настройки»
         settings_row = QWidget()
@@ -242,30 +233,11 @@ class StrategyControlDialog(QDialog):
         paused = bool(st and hasattr(st, "is_paused") and st.is_paused())
 
         if not bot_exists:
-            self.lbl_status.setText("Статус: завершён / удалён")
             self.btn_start.setEnabled(False)
             self.btn_pause.setEnabled(False)
             self.btn_resume.setEnabled(False)
             self.btn_stop.setEnabled(False)
             return
-
-        if not started and not st:
-            status = "Статус: не запущено"
-        elif running and paused:
-            status = "Статус: пауза"
-        elif running:
-            status = "Статус: работает"
-        else:
-            status = "Статус: остановлено"
-        self.lbl_status.setText(status)
-
-        ccy = (
-            st.params.get("account_currency")
-            if (st and isinstance(getattr(st, "params", None), dict))
-            else None
-        )
-        if ccy:
-            self.lbl_ccy.setText(f"Валюта счёта: {ccy}")
 
         self.btn_start.setEnabled(bot_exists and not started)
         self.btn_pause.setEnabled(running and not paused)
@@ -332,8 +304,6 @@ class StrategyControlDialog(QDialog):
             "min_balance": self.min_balance.value(),
             "coefficient": self.coefficient.value(),
             "min_percent": self.min_percent.value(),
-            "wait_on_low_percent": self.wait_on_low_percent.value(),
-            "signal_timeout_sec": self.signal_timeout_sec.value(),
             "minutes": int(norm),
         }
 
@@ -357,6 +327,7 @@ class StrategyControlDialog(QDialog):
         self,
         *,
         trade_id: str,
+        signal_at: str,
         placed_at: str,
         symbol: str,
         timeframe: str,
@@ -401,21 +372,24 @@ class StrategyControlDialog(QDialog):
         )
         ccy = getattr(self.main, "account_currency", "RUB")
         ind_txt = indicator or "—"
+        duration_txt = f"{int(round(float(wait_seconds) / 60))} мин"
 
         vals = [
-            placed_at,  # 0 Время
-            symbol,  # 1 Пара
-            timeframe,  # 2 ТФ
-            ind_txt,  # 3 Индикатор
-            dir_text,  # 4 Направление
-            self._fmt_money(stake, ccy),  # 5 Ставка
-            f"{percent}%",  # 6 %
-            f"Ожидание ({_fmt_left(left_now)})",  # 7 P/L
-            account_txt,  # 8 Счёт
+            signal_at,  # 0 Время сигнала
+            placed_at,  # 1 Время ставки
+            symbol,  # 2 Пара
+            timeframe,  # 3 ТФ
+            ind_txt,  # 4 Индикатор
+            dir_text,  # 5 Направление
+            self._fmt_money(stake, ccy),  # 6 Ставка
+            duration_txt,  # 7 Время
+            f"{percent}%",  # 8 %
+            f"Ожидание ({_fmt_left(left_now)})",  # 9 P/L
+            account_txt,  # 10 Счёт
         ]
         for col, v in enumerate(vals):
             it = QTableWidgetItem(str(v))
-            if col in (4, 7):
+            if col in (5, 9):
                 it.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             self.trades_table.setItem(row, col, it)
 
@@ -433,7 +407,7 @@ class StrategyControlDialog(QDialog):
             if row >= self.trades_table.rowCount():
                 timer.stop()
                 return
-            item = self.trades_table.item(row, 7)
+            item = self.trades_table.item(row, 9)
             if item:
                 item.setText(f"Ожидание ({_fmt_left(left)})")
             if left <= 0:
@@ -454,6 +428,9 @@ class StrategyControlDialog(QDialog):
             "timer": timer,
             "expected_end_ts": float(expected_end_ts),
             "indicator": ind_txt,
+            "signal_at": signal_at,
+            "placed_at": placed_at,
+            "wait_seconds": float(wait_seconds),
         }
 
         if was_sort:
@@ -463,6 +440,7 @@ class StrategyControlDialog(QDialog):
         self,
         *,
         trade_id: str | None = None,
+        signal_at: str,
         placed_at: str,
         symbol: str,
         timeframe: str,
@@ -485,6 +463,10 @@ class StrategyControlDialog(QDialog):
 
         # найти существующую строку по trade_id (если была pending)
         row_to_update = None
+        ind_txt = indicator or "—"
+        sig_time = signal_at
+        place_time = placed_at
+        duration_txt = ""
         if trade_id and trade_id in self._pending_rows:
             info = self._pending_rows.pop(trade_id, {})
             timer = info.get("timer")
@@ -496,6 +478,10 @@ class StrategyControlDialog(QDialog):
             row = info.get("row")
             if isinstance(row, int) and 0 <= row < self.trades_table.rowCount():
                 row_to_update = row
+                ind_txt = info.get("indicator", ind_txt)
+                sig_time = info.get("signal_at", sig_time)
+                place_time = info.get("placed_at", place_time)
+                duration_txt = f"{int(round(info.get('wait_seconds', 0.0) / 60))} мин"
 
         was_sort = self.trades_table.isSortingEnabled()
         if was_sort:
@@ -510,21 +496,25 @@ class StrategyControlDialog(QDialog):
             "ДЕМО" if getattr(self.main, "is_demo", False) else "РЕАЛ"
         )
         ccy = getattr(self.main, "account_currency", "RUB")
-        ind_txt = indicator or "—"
 
         vals = [
-            placed_at,  # 0
-            symbol,  # 1
-            timeframe,  # 2
-            ind_txt,  # 3
-            dir_text,  # 4
-            self._fmt_money(stake, ccy),  # 5
-            f"{percent}%",  # 6
-            fmt_pl(profit, ccy),  # 7
-            account_txt,  # 8
+            sig_time,  # 0
+            place_time,  # 1
+            symbol,  # 2
+            timeframe,  # 3
+            ind_txt,  # 4
+            dir_text,  # 5
+            self._fmt_money(stake, ccy),  # 6
+            duration_txt,  # 7
+            f"{percent}%",  # 8
+            fmt_pl(profit, ccy),  # 9
+            account_txt,  # 10
         ]
         for col, v in enumerate(vals):
-            self.trades_table.setItem(row_to_update, col, QTableWidgetItem(str(v)))
+            item = QTableWidgetItem(str(v))
+            if col in (5, 9):
+                item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.trades_table.setItem(row_to_update, col, item)
 
         if profit is None or abs(profit) < 1e-9:
             color = QColor("#e0e0e0")

--- a/gui/trades_table_widget.py
+++ b/gui/trades_table_widget.py
@@ -9,24 +9,28 @@ class TradesTableWidget(QTableWidget):
     """
     Таблица сделок.
     Колонки:
-      [0] Время
-      [1] Индикатор        <-- ОТ КОГО ПРИШЁЛ СИГНАЛ
-      [2] Валютная пара
-      [3] ТФ
-      [4] Направление
-      [5] Ставка
-      [6] Процент
-      [7] P/L
-      [8] Счёт
+      [0] Время сигнала
+      [1] Время ставки
+      [2] Индикатор        <-- ОТ КОГО ПРИШЁЛ СИГНАЛ
+      [3] Валютная пара
+      [4] ТФ
+      [5] Направление
+      [6] Ставка
+      [7] Время
+      [8] Процент
+      [9] P/L
+      [10] Счёт
     """
 
     COLS = [
-        "Время",
+        "Время сигнала",
+        "Время ставки",
         "Индикатор",
         "Валютная пара",
         "ТФ",
         "Направление",
         "Ставка",
+        "Время",
         "Процент",
         "P/L",
         "Счет",
@@ -38,8 +42,9 @@ class TradesTableWidget(QTableWidget):
         self.setHorizontalHeaderLabels(self.COLS)
 
         hdr = self.horizontalHeader()
-        hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)  # Время
-        for c in range(1, len(self.COLS)):
+        hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)  # Время сигнала
+        hdr.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)  # Время ставки
+        for c in range(2, len(self.COLS)):
             hdr.setSectionResizeMode(c, QHeaderView.ResizeMode.ResizeToContents)
 
         self.setAlternatingRowColors(True)
@@ -50,11 +55,13 @@ class TradesTableWidget(QTableWidget):
     def add_pending(
         self,
         trade_id: str,
+        signal_at: str,
         placed_at: str,
         symbol: str,
         timeframe: str,
         direction: int,  # 1=UP, 2=DOWN
         stake: float,
+        duration: float,
         percent: int,
         account_mode: str,  # "ДЕМО"/"РЕАЛ"
         indicator: str = "-",  # НАЗВАНИЕ ИНДИКАТОРА
@@ -64,19 +71,21 @@ class TradesTableWidget(QTableWidget):
 
         dir_text = "ВВЕРХ" if int(direction) == 1 else "ВНИЗ"
         values = [
+            signal_at,
             placed_at,
             indicator or "-",
             symbol,
             timeframe,
             dir_text,
             f"{stake:.2f}",
+            f"{int(round(duration / 60))} мин",
             f"{percent}%",
             "ожидание…",
             account_mode,
         ]
         for col, val in enumerate(values):
             it = QTableWidgetItem(str(val))
-            if col in (4, 7):  # выравнивание Направление, P/L по центру
+            if col in (5, 9):  # выравнивание Направление, P/L по центру
                 it.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             self.setItem(row, col, it)
 
@@ -93,11 +102,11 @@ class TradesTableWidget(QTableWidget):
             return
         row = self._row_by_trade[trade_id]
 
-        pl_item = self.item(row, 7)
+        pl_item = self.item(row, 9)
         if pl_item is None:
             pl_item = QTableWidgetItem()
             pl_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
-            self.setItem(row, 7, pl_item)
+            self.setItem(row, 9, pl_item)
 
         if profit is None:
             pl_item.setText("неизв.")


### PR DESCRIPTION
## Summary
- allow selecting all currency pairs and timeframes for bots
- restrict Martingale strategy to a single pair/timeframe
- split deals table time column into signal time and trade time
- disable global symbol/timeframe options for Martingale, showing an error if attempted
- move strategy selection to the top of the add-bot dialog
- preserve bet time and show trade duration in deal tables
- streamline strategy control dialog with timeframe label and fewer settings

## Testing
- `python -m py_compile gui/bot_add_dialog.py gui/main_window.py gui/strategy_control_dialog.py gui/trades_table_widget.py gui/settings_martingale.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad38b01b748322a152b9199f1397ef