### PR TITLE
Clean format for strategy settings and amounts

### DIFF
--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -20,6 +20,7 @@ from PyQt6.QtGui import QColor, QBrush
 from PyQt6.QtCore import QTimer, Qt
 from strategies.martingale import _minutes_from_timeframe
 from core.policy import normalize_sprint
+from core.money import format_money
 
 
 class StrategyControlDialog(QDialog):
@@ -327,7 +328,7 @@ class StrategyControlDialog(QDialog):
             v = float(value)
         except Exception:
             v = 0.0
-        return f"{v:.2f} {ccy}"
+        return format_money(v, ccy)
 
     def _add_trade_pending_local(
         self,

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -134,7 +134,11 @@ class StrategyBase:
     def update_params(self, **params):
         self.params.update(params)
         if hasattr(self, "log") and self.log:
-            self.log(f"[{self.symbol}] ⚙ Параметры обновлены: {params}")
+            pretty = {
+                k: (round(v, 8) if isinstance(v, float) else v)
+                for k, v in params.items()
+            }
+            self.log(f"[{self.symbol}] ⚙ Параметры обновлены: {pretty}")
 
     def get_param(self, key, default=None):
         return self.params.get(key, default)


### PR DESCRIPTION
## Summary
- round float params when logging strategy updates to avoid long tails
- display currency amounts with symbols in strategy control dialog

## Testing
- `python -m py_compile strategies/base.py gui/strategy_control_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad5d94fb7c8322b42b8ed9649e69fb