### PR TITLE
Delay trade result polling until near expiry

### DIFF
--- a/core/intrade_api.py
+++ b/core/intrade_api.py
@@ -231,15 +231,45 @@ def place_trade(
     return None
 
 
-async def check_trade_result(session, user_id, user_hash, trade_id, wait_time):
-    await asyncio.sleep(wait_time)
+async def check_trade_result(
+    session,
+    user_id,
+    user_hash,
+    trade_id,
+    wait_time: float = 60.0,
+    poll_interval: float = 1.0,
+    initial_wait: float | None = None,
+):
+    """Опрашивает результат сделки до wait_time секунд.
+
+    Возвращает profit (result - investment) или None, если результат не получен.
+
+    initial_wait — сколько секунд подождать перед первым запросом
+                   (по умолчанию poll_interval).
+    """
+    deadline = asyncio.get_running_loop().time() + float(wait_time)
     payload = {"user_id": user_id, "user_hash": user_hash, "trade_id": trade_id}
-    r = session.post(TRADE_CHECK_URL, data=payload)
-    parts = r.text.strip().split(";")
-    if len(parts) >= 3:
+
+    if wait_time > 0:
+        delay = poll_interval if initial_wait is None else float(initial_wait)
+        await asyncio.sleep(min(delay, wait_time))
+
+    while True:
         try:
-            rate, result, investment = parts
-            return float(result) - float(investment)
-        except:
-            return None
+            r = session.post(TRADE_CHECK_URL, data=payload)
+            parts = r.text.strip().split(";")
+        except Exception:
+            parts = []
+        if len(parts) >= 3:
+            try:
+                rate, result, investment = parts[:3]
+                return float(result) - float(investment)
+            except Exception:
+                pass
+
+        left = deadline - asyncio.get_running_loop().time()
+        if left <= 0:
+            break
+        await asyncio.sleep(min(poll_interval, left))
+
     return None

--- a/core/intrade_api_async.py
+++ b/core/intrade_api_async.py
@@ -177,22 +177,45 @@ async def check_trade_result(
     user_id: str,
     user_hash: str,
     trade_id: str,
-    wait_time: float,
+    wait_time: float = 60.0,
+    poll_interval: float = 1.0,
+    initial_wait: float | None = None,
 ) -> Optional[float]:
     """
-    Ждёт wait_time сек, затем запрашивает результат.
-    Возвращает profit (result - investment) как float, либо None.
+    Периодически опрашивает сервер о результате сделки, возвращая profit
+    (result - investment) как float, либо None.
+
+    wait_time     – максимальное время ожидания в секундах.
+    poll_interval – интервал между повторными запросами.
+    initial_wait  – сколько секунд подождать перед первым запросом
+                    (по умолчанию poll_interval).
     """
-    await asyncio.sleep(wait_time)
+    deadline = asyncio.get_running_loop().time() + float(wait_time)
     payload = {"user_id": user_id, "user_hash": user_hash, "trade_id": trade_id}
-    text = await client.post(PATH_TRADE_CHECK, data=payload, expect_json=False)
-    parts = str(text).strip().split(";")
-    if len(parts) >= 3:
+
+    # пауза перед первым запросом, чтобы не дёргать сервер слишком рано
+    if wait_time > 0:
+        delay = poll_interval if initial_wait is None else float(initial_wait)
+        await asyncio.sleep(min(delay, wait_time))
+
+    while True:
         try:
-            rate, result, investment = parts[:3]
-            return float(result) - float(investment)
+            text = await client.post(PATH_TRADE_CHECK, data=payload, expect_json=False)
         except Exception:
-            return None
+            text = None
+        parts = str(text).strip().split(";") if text is not None else []
+        if len(parts) >= 3:
+            try:
+                rate, result, investment = parts[:3]
+                return float(result) - float(investment)
+            except Exception:
+                pass
+
+        left = deadline - asyncio.get_running_loop().time()
+        if left <= 0:
+            break
+        await asyncio.sleep(min(poll_interval, left))
+
     return None
 
 

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -20,6 +20,7 @@ from PyQt6.QtGui import QColor, QBrush
 from PyQt6.QtCore import QTimer, Qt
 from strategies.martingale import _minutes_from_timeframe
 from core.policy import normalize_sprint
+from core.money import format_money
 
 
 class StrategyControlDialog(QDialog):
@@ -327,7 +328,7 @@ class StrategyControlDialog(QDialog):
             v = float(value)
         except Exception:
             v = 0.0
-        return f"{v:.2f} {ccy}"
+        return format_money(v, ccy)
 
     def _add_trade_pending_local(
         self,

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -134,7 +134,11 @@ class StrategyBase:
     def update_params(self, **params):
         self.params.update(params)
         if hasattr(self, "log") and self.log:
-            self.log(f"[{self.symbol}] ⚙ Параметры обновлены: {params}")
+            pretty = {
+                k: (round(v, 8) if isinstance(v, float) else v)
+                for k, v in params.items()
+            }
+            self.log(f"[{self.symbol}] ⚙ Параметры обновлены: {pretty}")
 
     def get_param(self, key, default=None):
         return self.params.get(key, default)

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -131,6 +131,7 @@ class MartingaleStrategy(StrategyBase):
         self._last_signal_at_str: Optional[str] = (
             None  # <=== НОВОЕ: время прихода сигнала
         )
+        self._last_signal_mono: Optional[float] = None  # loop.time() прихода сигнала
 
         anchor = str(
             self.params.get("account_currency", DEFAULTS["account_currency"])
@@ -369,12 +370,21 @@ class MartingaleStrategy(StrategyBase):
 
                 self._status("ожидание результата")
 
+                # подсчитываем, сколько времени прошло с момента прихода сигнала
+                delay = 0.0
+                if self._last_signal_mono is not None:
+                    delay = asyncio.get_running_loop().time() - self._last_signal_mono
+
+                remaining = max(float(result_wait_s) - delay, 0.0)
+                pre_wait = max(remaining - 5.0, 0.0)
+
                 profit = await check_trade_result(
                     self.http_client,
                     user_id=self.user_id,
                     user_hash=self.user_hash,
                     trade_id=trade_id,
-                    wait_time=result_wait_s,
+                    wait_time=remaining,
+                    initial_wait=pre_wait,
                 )
 
                 if callable(self._on_trade_result):
@@ -497,6 +507,7 @@ class MartingaleStrategy(StrategyBase):
         from datetime import datetime
 
         self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+        self._last_signal_mono = asyncio.get_running_loop().time()
         return int(direction)
 
     def update_params(self, **params):


### PR DESCRIPTION
## Summary
- add `initial_wait` option to `check_trade_result` to postpone first server request
- track signal arrival time in martingale strategy and wait until 5s before expiry before polling for trade result

## Testing
- `python -m py_compile core/intrade_api_async.py core/intrade_api.py strategies/martingale.py`
- `python -m py_compile strategies/oscar_grind.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad5d94fb7c8322b42b8ed9649e69fb