### PR TITLE
Improve settings formatting and signal timing

### DIFF
--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -94,15 +94,19 @@ class StrategyControlDialog(QDialog):
         hdr.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)  # Время ставки
         hdr.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)  # Пара
         hdr.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)  # ТФ
-        hdr.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)  # Индикатор
-        hdr.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)  # Направление
+        hdr.setSectionResizeMode(
+            4, QHeaderView.ResizeMode.ResizeToContents
+        )  # Индикатор
+        hdr.setSectionResizeMode(
+            5, QHeaderView.ResizeMode.ResizeToContents
+        )  # Направление
         hdr.setSectionResizeMode(6, QHeaderView.ResizeMode.ResizeToContents)  # Ставка
         hdr.setSectionResizeMode(7, QHeaderView.ResizeMode.ResizeToContents)  # Время
         hdr.setSectionResizeMode(8, QHeaderView.ResizeMode.ResizeToContents)  # %
         hdr.setSectionResizeMode(9, QHeaderView.ResizeMode.ResizeToContents)  # P/L
         hdr.setSectionResizeMode(10, QHeaderView.ResizeMode.ResizeToContents)  # Счёт
         self.trades_table.setAlternatingRowColors(True)
-        self.trades_table.setSortingEnabled(True)
+        self.trades_table.setSortingEnabled(False)
 
         # ---------- Настройки (inline) ----------
         self.settings_box = QGroupBox("Настройки стратегии")
@@ -309,7 +313,7 @@ class StrategyControlDialog(QDialog):
             "max_steps": self.max_steps.value(),
             "repeat_count": self.repeat_count.value(),
             "min_balance": self.min_balance.value(),
-            "coefficient": self.coefficient.value(),
+            "coefficient": round(float(self.coefficient.value()), 2),
             "min_percent": self.min_percent.value(),
             "minutes": int(norm),
         }
@@ -319,7 +323,14 @@ class StrategyControlDialog(QDialog):
             self.bot.strategy.update_params(**new_params)
 
         self.minutes.setValue(int(norm))
-        self.log_edit.append(f"💾 Настройки сохранены: {new_params}")
+
+        formatted = []
+        for k, v in new_params.items():
+            if isinstance(v, float):
+                formatted.append(f"'{k}': {v:.2f}")
+            else:
+                formatted.append(f"'{k}': {v}")
+        self.log_edit.append("💾 Настройки сохранены: {" + ", ".join(formatted) + "}")
 
     # ---- хелперы: локальная таблица сделок ----
     def _fmt_money(self, value: float, ccy: str) -> str:

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -189,6 +189,7 @@ class MartingaleStrategy(StrategyBase):
             self._last_signal_ver = 0
 
         while self._running and series_left > 0:
+            self._last_signal_at_str = None
             await self._pause_point()
 
             if not await self._ensure_anchor_currency():
@@ -355,7 +356,7 @@ class MartingaleStrategy(StrategyBase):
                             trade_id=trade_id,
                             symbol=self.symbol,
                             timeframe=self.timeframe,
-                            signal_at=(self._last_signal_at_str or placed_at_str),
+                            signal_at=self._last_signal_at_str,
                             placed_at=placed_at_str,
                             direction=status,
                             stake=float(stake),
@@ -386,7 +387,7 @@ class MartingaleStrategy(StrategyBase):
                             trade_id=trade_id,
                             symbol=self.symbol,
                             timeframe=self.timeframe,
-                            signal_at=(self._last_signal_at_str or placed_at_str),
+                            signal_at=self._last_signal_at_str,
                             placed_at=placed_at_str,
                             direction=status,
                             stake=float(stake),


### PR DESCRIPTION
## Summary
- format strategy coefficient with two decimals in settings log
- disable column sorting in strategy control trades table
- keep original signal time for repeated martingale trades

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad85b9810083229ad339e868fb92b6