### PR TITLE
Disable selection in trade tables and wait for newest signals

### DIFF
--- a/core/signal_waiter.py
+++ b/core/signal_waiter.py
@@ -192,10 +192,12 @@ async def wait_for_signal(
     timeout: Optional[float] = None,
     raise_on_timeout: bool = True,
 ) -> int:
+    # Всегда ждём следующий сигнал, игнорируя уже полученные ранее.
+    st = _states[_key(symbol, timeframe)]
     direction, _ = await wait_for_signal_versioned(
         symbol,
         timeframe,
-        since_version=None,  # NB: стратегия, желающая избегать повторов, должна хранить версию сама
+        since_version=st.version,
         check_pause=check_pause,
         timeout=timeout,
         raise_on_timeout=raise_on_timeout,

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -228,6 +228,9 @@ class MainWindow(QWidget):
         hdr.setSectionResizeMode(10, QHeaderView.ResizeMode.ResizeToContents)
         self.trades_table.setAlternatingRowColors(True)
         # self.trades_table.setSortingEnabled(True)
+        self.trades_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.trades_table.setSelectionMode(QTableWidget.SelectionMode.NoSelection)
+        self.trades_table.setFocusPolicy(Qt.FocusPolicy.NoFocus)
 
         layout = QVBoxLayout()
         layout.addLayout(top_layout)

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -107,6 +107,9 @@ class StrategyControlDialog(QDialog):
         hdr.setSectionResizeMode(10, QHeaderView.ResizeMode.ResizeToContents)  # Счёт
         self.trades_table.setAlternatingRowColors(True)
         self.trades_table.setSortingEnabled(False)
+        self.trades_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.trades_table.setSelectionMode(QTableWidget.SelectionMode.NoSelection)
+        self.trades_table.setFocusPolicy(Qt.FocusPolicy.NoFocus)
 
         # ---------- Настройки (inline) ----------
         self.settings_box = QGroupBox("Настройки стратегии")

--- a/gui/trades_table_widget.py
+++ b/gui/trades_table_widget.py
@@ -49,6 +49,9 @@ class TradesTableWidget(QTableWidget):
 
         self.setAlternatingRowColors(True)
         self.setSortingEnabled(True)
+        self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.setSelectionMode(QTableWidget.SelectionMode.NoSelection)
+        self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         # trade_id -> row
         self._row_by_trade: dict[str, int] = {}
 


### PR DESCRIPTION
## Summary
- prevent cell/column selection in trade tables across UI
- ensure bots wait for next incoming signal instead of reusing last signal

## Testing
- `python -m py_compile gui/main_window.py gui/strategy_control_dialog.py gui/trades_table_widget.py core/signal_waiter.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad90eb6a908322a88b6ad626734c2b