### PR TITLE
refactor: improve bot infrastructure and ws client

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -1,18 +1,31 @@
-# core/bot.py
+"""Асинхронный контейнер для работы стратегии бота."""
+
+from __future__ import annotations
+
 import asyncio
+from typing import Any, Callable, Optional, Type
 
 
 class Bot:
-    def __init__(self, strategy_cls, strategy_kwargs, on_log, on_finish):
+    """Запускает стратегию в отдельной асинхронной задаче."""
+
+    def __init__(
+        self,
+        strategy_cls: Type,
+        strategy_kwargs: dict[str, Any],
+        on_log: Callable[[str], None],
+        on_finish: Callable[[], None],
+    ) -> None:
         self.strategy_cls = strategy_cls
         self.strategy_kwargs = strategy_kwargs
         self.on_log = on_log
         self.on_finish = on_finish
-        self._task = None
-        self._strategy = None
+        self._task: Optional[asyncio.Task] = None
+        self._strategy: Optional[Any] = None
         self._started = False
 
-    def start(self):
+    def start(self) -> None:
+        """Создать экземпляр стратегии и запустить её."""
         if self._started:
             return
         self._strategy = self.strategy_cls(**self.strategy_kwargs)
@@ -28,7 +41,8 @@ class Bot:
         self._task = asyncio.create_task(self._run())
         self._started = True
 
-    async def _run(self):
+    async def _run(self) -> None:
+        """Внутренний цикл исполнения стратегии."""
         try:
             await self._strategy.run()
         except asyncio.CancelledError:
@@ -53,26 +67,32 @@ class Bot:
             self._started = False
             self.on_finish()
 
-    def stop(self):
+    def stop(self) -> None:
+        """Остановить стратегию и отменить асинхронную задачу."""
         if self._strategy:
             self._strategy.stop()
         if self._task and not self._task.done():
             self._task.cancel()
 
-    def pause(self):
+    def pause(self) -> None:
+        """Поставить стратегию на паузу, если она поддерживает паузу."""
         if self._strategy:
             self._strategy.pause()
 
-    def resume(self):
+    def resume(self) -> None:
+        """Возобновить стратегию после паузы."""
         if self._strategy:
             self._strategy.resume()
 
-    def is_running(self):
+    def is_running(self) -> bool:
+        """Проверить, выполняется ли задача стратегии."""
         return bool(self._task and not self._task.done())
 
-    def has_started(self):
+    def has_started(self) -> bool:
+        """Стартовал ли бот ранее."""
         return self._started
 
     @property
-    def strategy(self):
+    def strategy(self) -> Optional[Any]:
+        """Возвращает инстанс стратегии (если запущен)."""
         return self._strategy

--- a/core/bot_manager.py
+++ b/core/bot_manager.py
@@ -1,29 +1,46 @@
+"""Управление жизненным циклом всех запущенных ботов."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Type
+
 from core.bot import Bot
 
 
 class BotManager:
-    def __init__(self):
-        self.bots = []
+    """Коллекция всех активных ботов."""
 
-    def add_bot(self, bot: Bot):
+    def __init__(self) -> None:
+        self.bots: List[Bot] = []
+
+    def add_bot(self, bot: Bot) -> None:
+        """Добавить бота в менеджер."""
         self.bots.append(bot)
 
-    def remove_bot(self, bot: Bot):
+    def remove_bot(self, bot: Bot) -> None:
+        """Остановить и удалить бота из менеджера."""
         if bot in self.bots:
             bot.stop()
             self.bots.remove(bot)
 
-    def get_all_bots(self):
-        return self.bots
+    def get_all_bots(self) -> Iterable[Bot]:
+        """Вернуть итератор по всем зарегистрированным ботам."""
+        return list(self.bots)
 
-    def stop_all(self):
-        for bot in self.bots:
+    def stop_all(self) -> None:
+        """Остановить всех ботов."""
+        for bot in list(self.bots):
             bot.stop()
 
-    def find_by_symbol_and_strategy(self, symbol: str, strategy_cls):
+    def find_by_symbol_and_strategy(
+        self, symbol: str, strategy_cls: Type
+    ) -> Optional[Bot]:
+        """Найти бота по символу и классу стратегии."""
         for bot in self.bots:
-            if (bot.strategy_kwargs.get("symbol") == symbol
-                    and bot.strategy_cls == strategy_cls):
+            if (
+                bot.strategy_kwargs.get("symbol") == symbol
+                and bot.strategy_cls == strategy_cls
+            ):
                 return bot
         return None
 

--- a/core/ws_client.py
+++ b/core/ws_client.py
@@ -1,28 +1,44 @@
-import sys
-import json
+"""WebSocket client responsible for receiving trading signals."""
+
+from __future__ import annotations
+
 import asyncio
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
 import websockets
 from PyQt6.QtWidgets import QApplication, QMessageBox
-from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
 
 from core.signal_waiter import push_signal  # <-- добавили
 
+
 signal_log_callback = None
 
-timeframe_map = {
-    "M1": timedelta(minutes=1),
-    "M5": timedelta(minutes=5),
-    "M15": timedelta(minutes=15),
-    "M30": timedelta(minutes=30),
-    "H1": timedelta(hours=1),
-    "H4": timedelta(hours=4),
-    "D1": timedelta(days=1),
-    "W1": timedelta(weeks=1),
+
+# Поддерживаемые таймфреймы. Значения не используются напрямую, важен только ключ.
+_TIMEFRAME_MAP = {
+    "M1": 1,
+    "M5": 5,
+    "M15": 15,
+    "M30": 30,
+    "H1": 60,
+    "H4": 240,
+    "D1": 1440,
+    "W1": 10080,
 }
 
 
-def show_connection_error(error_text: str):
+def _log(message: str) -> None:
+    """Отправить сообщение через колбэк лога, если он установлен."""
+    if signal_log_callback:
+        signal_log_callback(message)
+
+
+def show_connection_error(error_text: str) -> None:
+    """Показать диалог с ошибкой подключения и завершить приложение."""
     app = QApplication.instance()
     if app is None:
         app = QApplication(sys.argv)
@@ -35,7 +51,57 @@ def show_connection_error(error_text: str):
     raise SystemExit(1)
 
 
-async def listen_to_signals():
+@dataclass
+class SignalMessage:
+    """Нормализованное сообщение сигнала, полученное через WebSocket."""
+
+    symbol: str
+    timeframe: str
+    direction: Optional[int]
+    indicator: str
+    timestamp: datetime
+
+
+def _parse_direction(raw_dir: Any) -> Optional[int]:
+    """Привести поле direction к 1, 2 или None."""
+    if isinstance(raw_dir, int):
+        return raw_dir if raw_dir in (1, 2) else None
+    if isinstance(raw_dir, str):
+        d = raw_dir.strip().lower()
+        if d in ("1", "up", "buy", "long"):
+            return 1
+        if d in ("2", "down", "sell", "short"):
+            return 2
+    return None
+
+
+def _parse_message(message: str) -> Optional[SignalMessage]:
+    """Распарсить JSON-сообщение в структуру SignalMessage."""
+    try:
+        data = json.loads(message)
+    except json.JSONDecodeError:
+        print("[WS] Ошибка парсинга сигнала.")
+        return None
+
+    symbol = (data.get("symbol") or "").upper()
+    timeframe = (data.get("timeframe") or "").upper()
+    dt_str = data.get("datetime", "")
+    indicator = data.get("indicator", "")
+
+    if not (symbol and timeframe and dt_str):
+        return None
+    if timeframe not in _TIMEFRAME_MAP:
+        _log(f"[WS] Неизвестный таймфрейм '{timeframe}' — игнор.")
+        return None
+
+    direction = _parse_direction(data.get("direction"))
+    timestamp = datetime.fromisoformat(dt_str)
+    return SignalMessage(symbol, timeframe, direction, indicator, timestamp)
+
+
+async def listen_to_signals() -> None:
+    """Подключиться к серверу и слушать входящие сигналы."""
+
     from core.config import ws_url
 
     retry = 0
@@ -45,63 +111,22 @@ async def listen_to_signals():
                 ws_url, ping_interval=20, ping_timeout=10
             ) as websocket:
                 retry = 0
-                signal_log_callback("[WS] Подключено к WebSocket-серверу.")
+                _log("[WS] Подключено к WebSocket-серверу.")
                 async for message in websocket:
-                    try:
-                        data = json.loads(message)
+                    sig = _parse_message(message)
+                    if sig is None:
+                        continue
 
-                        symbol = (data.get("symbol") or "").upper()
-                        timeframe = (data.get("timeframe") or "").upper()
-                        date_time_str = data.get("datetime", "")
+                    # ВАЖНО: отправляем в ожидатель ВСЕ сообщения (включая none)
+                    push_signal(sig.symbol, sig.timeframe, sig.direction, sig.indicator)
 
-                        # direction может быть 0/1/2 или строкой 'none' / 'up' / 'down'
-                        raw_dir = data.get("direction", None)
-                        indicator = data.get("indicator", "")
-
-                        # нормализуем в {1,2,None}
-                        direction = None
-                        if isinstance(raw_dir, int):
-                            if raw_dir in (1, 2):
-                                direction = raw_dir
-                            else:
-                                direction = None  # 0 или любой другой => none / очистка
-                        elif isinstance(raw_dir, str):
-                            d = raw_dir.strip().lower()
-                            if d in ("1", "up", "buy", "long"):
-                                direction = 1
-                            elif d in ("2", "down", "sell", "short"):
-                                direction = 2
-                            else:
-                                direction = None  # 'none' и т.п.
-
-                        if symbol and timeframe and date_time_str:
-                            td = timeframe_map.get(timeframe)
-                            if td is None:
-                                if signal_log_callback:
-                                    signal_log_callback(
-                                        f"[WS] Неизвестный таймфрейм '{timeframe}' — игнор."
-                                    )
-                                continue
-
-                            # ВАЖНО: отправляем в ожидатель ВСЕ сообщения (включая none)
-                            push_signal(symbol, timeframe, direction, indicator)
-
-                            # просто лог (для наглядности)
-                            dt = datetime.fromisoformat(date_time_str)
-                            dt_naive = dt.replace(tzinfo=None)
-                            msg_dir = {1: "UP", 2: "DOWN", None: "none"}[direction]
-                            if signal_log_callback:
-                                signal_log_callback(
-                                    f"[WS] {symbol} / {timeframe}. Прогноз: {msg_dir} от {indicator}. Время свечи: {dt_naive.strftime('%H:%M')}"
-                                )
-
-                    except json.JSONDecodeError:
-                        print("[WS] Ошибка парсинга сигнала.")
+                    dt_naive = sig.timestamp.replace(tzinfo=None)
+                    msg_dir = {1: "UP", 2: "DOWN", None: "none"}[sig.direction]
+                    _log(
+                        f"[WS] {sig.symbol} / {sig.timeframe}. Прогноз: {msg_dir} от {sig.indicator}. Время свечи: {dt_naive.strftime('%H:%M')}"
+                    )
         except Exception as e:
             delay = min(30, 2 ** min(retry, 5))
-            if signal_log_callback:
-                signal_log_callback(
-                    f"[WS] Потеря соединения: {e}. Повтор через {delay}c"
-                )
+            _log(f"[WS] Потеря соединения: {e}. Повтор через {delay}c")
             await asyncio.sleep(delay)
             retry += 1


### PR DESCRIPTION
## Summary
- add dataclass-based parser and logging helpers for WebSocket signals
- document and type Bot and BotManager infrastructure

## Testing
- `python -m py_compile core/bot.py core/bot_manager.py core/ws_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68adacf519108322804684577c1482f2