### PR TITLE
Add Oscar Grind trading strategy

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -38,6 +38,7 @@ from core.ws_client import listen_to_signals
 from core.bot_manager import BotManager
 from core.bot import Bot
 from strategies.martingale import MartingaleStrategy
+from strategies.oscar_grind import OscarGrindStrategy
 
 
 class MainWindow(QWidget):
@@ -80,8 +81,14 @@ class MainWindow(QWidget):
             "USD/JPY",
             "BTC/USDT",
         ]
-        self.available_strategies = {"martingale": MartingaleStrategy}
-        self.strategy_labels = {"martingale": "Мартингейл"}
+        self.available_strategies = {
+            "martingale": MartingaleStrategy,
+            "oscar_grind": OscarGrindStrategy,
+        }
+        self.strategy_labels = {
+            "martingale": "Мартингейл",
+            "oscar_grind": "Оскар Грайнд",
+        }
 
         self.bot_ever_started = defaultdict(bool)
         self.bot_logs = defaultdict(list)

--- a/gui/settings_factory.py
+++ b/gui/settings_factory.py
@@ -1,11 +1,13 @@
 from typing import Type, Dict
 from PyQt6.QtWidgets import QDialog
 from strategies.martingale import MartingaleStrategy
+from strategies.oscar_grind import OscarGrindStrategy
 from gui.settings_martingale import MartingaleSettingsDialog
+from gui.settings_oscar_grind import OscarGrindSettingsDialog
 
 _registry: Dict[Type, Type[QDialog]] = {
     MartingaleStrategy: MartingaleSettingsDialog,
-    # позже добавишь: OscarGrindStrategy: OscarGrindSettingsDialog
+    OscarGrindStrategy: OscarGrindSettingsDialog,
 }
 
 

--- a/gui/settings_oscar_grind.py
+++ b/gui/settings_oscar_grind.py
@@ -1,0 +1,72 @@
+from PyQt6.QtWidgets import (
+    QDialog,
+    QFormLayout,
+    QSpinBox,
+    QDialogButtonBox,
+)
+
+from strategies.martingale import _minutes_from_timeframe
+from core.policy import normalize_sprint
+
+
+class OscarGrindSettingsDialog(QDialog):
+    def __init__(self, params: dict, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Настройки: Oscar Grind")
+        self.params = params.copy()
+
+        tf = str(self.params.get("timeframe", "M1"))
+        symbol = str(self.params.get("symbol", ""))
+        default_minutes = int(self.params.get("minutes", _minutes_from_timeframe(tf)))
+
+        self.minutes = QSpinBox()
+        self.minutes.setRange(5 if symbol == "BTCUSDT" else 1, 500)
+        self.minutes.setValue(default_minutes)
+
+        self.base_investment = QSpinBox()
+        self.base_investment.setRange(1, 50000)
+        self.base_investment.setValue(self.params.get("base_investment", 100))
+
+        self.repeat_count = QSpinBox()
+        self.repeat_count.setRange(1, 1000)
+        self.repeat_count.setValue(self.params.get("repeat_count", 10))
+
+        self.min_balance = QSpinBox()
+        self.min_balance.setRange(1, 10_000_000)
+        self.min_balance.setValue(self.params.get("min_balance", 100))
+
+        self.min_percent = QSpinBox()
+        self.min_percent.setRange(0, 100)
+        self.min_percent.setValue(self.params.get("min_percent", 70))
+
+        form = QFormLayout()
+        form.addRow("Базовая ставка", self.base_investment)
+        form.addRow("Время экспирации (мин)", self.minutes)
+        form.addRow("Повторов серии", self.repeat_count)
+        form.addRow("Мин. баланс", self.min_balance)
+        form.addRow("Мин. процент", self.min_percent)
+
+        btns = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        btns.accepted.connect(self.accept)
+        btns.rejected.connect(self.reject)
+
+        form.addRow(btns)
+        self.setLayout(form)
+
+    def get_params(self) -> dict:
+        symbol = str(self.params.get("symbol", ""))
+        m = int(self.minutes.value())
+        norm = normalize_sprint(symbol, m)
+        if norm is None:
+            norm = 5 if symbol == "BTCUSDT" else (1 if m < 3 else max(3, min(500, m)))
+
+        return {
+            "minutes": int(norm),
+            "base_investment": self.base_investment.value(),
+            "repeat_count": self.repeat_count.value(),
+            "min_balance": self.min_balance.value(),
+            "min_percent": self.min_percent.value(),
+        }
+

--- a/strategies/oscar_grind.py
+++ b/strategies/oscar_grind.py
@@ -1,36 +1,258 @@
-from core.intrade_api import get_current_percent, place_trade, check_trade_result
+# strategies/oscar_grind.py
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from core.http_async import HttpClient
+from core.intrade_api_async import (
+    get_balance,
+    get_current_percent,
+    place_trade,
+    check_trade_result,
+)
 from core.signal_waiter import wait_for_signal
+from strategies.base import StrategyBase
+
+DEFAULTS = {
+    "base_investment": 100,
+    "repeat_count": 10,
+    "min_balance": 100,
+    "min_percent": 70,
+    "wait_on_low_percent": 1,
+    "signal_timeout_sec": 3600,
+    "account_currency": "RUB",
+    "minutes": 1,
+    "result_wait_s": 60.0,
+}
 
 
-async def oscar_grind_strategy(
-    session, user_id, user_hash, base_investment=100, symbol="EURUSD"
-):
-    total_profit = 0.0
-    investment = base_investment
-    trade_number = 1
+class OscarGrindStrategy(StrategyBase):
+    """"Оскар Грайнд" — управление ставками с целью получить
+    фиксированную прибыль за серию сделок.
 
-    while total_profit < base_investment:
-        percent = get_current_percent(session, investment, symbol)
-        if percent is None:
-            continue
+    Стратегия стремится заработать ``base_investment`` за серию.
+    При проигрыше ставка сохраняется, при выигрыше увеличивается на
+    ``base_investment`` (но не больше необходимого для достижения цели).
+    """
 
-        status = await wait_for_signal(symbol)
-        trade_id = place_trade(session, user_id, user_hash, investment, symbol, status)
-        if not trade_id:
-            continue
+    def __init__(
+        self,
+        http_client: HttpClient,
+        user_id: str,
+        user_hash: str,
+        symbol: str,
+        log_callback=None,
+        *,
+        timeframe: str = "M1",
+        params: Optional[dict] = None,
+        **_,
+    ):
+        p = dict(DEFAULTS)
+        if params:
+            p.update(params)
 
-        profit = await check_trade_result(session, user_id, user_hash, trade_id)
-        if profit is None:
-            continue
-
-        print(
-            f"[{symbol}] Сделка {trade_number}: {'ПРИБЫЛЬ' if profit > 0 else 'УБЫТОК'} {profit:.2f}"
+        super().__init__(
+            session=http_client,
+            user_id=user_id,
+            user_hash=user_hash,
+            symbol=symbol,
+            log_callback=log_callback,
+            **p,
         )
-        trade_number += 1
-        total_profit += profit
 
-        if profit > 0:
-            remaining = base_investment - total_profit
-            investment = max(100, remaining / (percent / 100.0))
-        else:
-            investment = min(investment + 100, 50000)
+        self.http_client = http_client
+        self.timeframe = timeframe or self.params.get("timeframe", "M1")
+        self.params["timeframe"] = self.timeframe
+
+        self._on_trade_result = self.params.get("on_trade_result")
+        self._on_trade_pending = self.params.get("on_trade_pending")
+        self._on_status = self.params.get("on_status")
+
+        def _status(msg: str):
+            cb = self._on_status
+            if callable(cb):
+                try:
+                    cb(msg)
+                except Exception:
+                    pass
+
+        self._status = _status
+
+    async def run(self) -> None:
+        self._running = True
+        log = self.log or (lambda s: None)
+
+        base = float(self.params.get("base_investment", DEFAULTS["base_investment"]))
+        repeat_count = int(self.params.get("repeat_count", DEFAULTS["repeat_count"]))
+        min_balance = float(self.params.get("min_balance", DEFAULTS["min_balance"]))
+        min_percent = int(self.params.get("min_percent", DEFAULTS["min_percent"]))
+        wait_low = float(
+            self.params.get("wait_on_low_percent", DEFAULTS["wait_on_low_percent"])
+        )
+        signal_timeout = float(
+            self.params.get("signal_timeout_sec", DEFAULTS["signal_timeout_sec"])
+        )
+        account_ccy = self.params.get(
+            "account_currency", DEFAULTS["account_currency"]
+        )
+        minutes = int(self.params.get("minutes", DEFAULTS["minutes"]))
+        result_wait_s = float(
+            self.params.get("result_wait_s", DEFAULTS["result_wait_s"])
+        )
+
+        series_left = repeat_count
+
+        while self._running and series_left > 0:
+            await self._pause_point()
+
+            # Проверка баланса перед серией
+            try:
+                bal = await get_balance(self.http_client, self.user_id, self.user_hash)
+                if bal < min_balance:
+                    log(
+                        f"[{self.symbol}] 🛑 Баланс {bal:.2f} ниже минимального {min_balance:.2f}"
+                    )
+                    break
+            except Exception:
+                pass
+
+            total_profit = 0.0
+            stake = base
+            trade_number = 1
+            self._status("ожидание сигнала")
+
+            log(
+                f"[{self.symbol}] 🔁 Новая серия Оскар Грайнд. Цель профита: {base:.2f}"
+            )
+
+            while self._running and total_profit < base:
+                await self._pause_point()
+
+                pct = await get_current_percent(
+                    self.http_client,
+                    stake,
+                    self.symbol,
+                    minutes,
+                    account_ccy,
+                )
+                if pct is None or pct < min_percent:
+                    await self.sleep(wait_low)
+                    continue
+
+                try:
+                    status = await wait_for_signal(
+                        self.symbol,
+                        self.timeframe,
+                        check_pause=self._pause_point,
+                        timeout=signal_timeout,
+                    )
+                except asyncio.TimeoutError:
+                    log(f"[{self.symbol}] ⏱️ Таймаут ожидания сигнала")
+                    continue
+
+                self._status("ожидание результата")
+
+                trade_id = await place_trade(
+                    self.http_client,
+                    self.user_id,
+                    self.user_hash,
+                    stake,
+                    self.symbol,
+                    status,
+                    minutes,
+                    account_ccy=account_ccy,
+                    strict=False,
+                    on_log=log,
+                )
+                if not trade_id:
+                    log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
+                    await self.sleep(1.0)
+                    continue
+
+                # GUI: уведомляем о размещении
+                if callable(self._on_trade_pending):
+                    from datetime import datetime
+
+                    placed_at = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+                    try:
+                        self._on_trade_pending(
+                            trade_id=trade_id,
+                            symbol=self.symbol,
+                            timeframe=self.timeframe,
+                            signal_at=None,
+                            placed_at=placed_at,
+                            direction=status,
+                            stake=float(stake),
+                            percent=int(pct),
+                            wait_seconds=float(result_wait_s),
+                            account_mode=None,
+                            indicator=None,
+                        )
+                    except Exception:
+                        pass
+
+                profit = await check_trade_result(
+                    self.http_client,
+                    user_id=self.user_id,
+                    user_hash=self.user_hash,
+                    trade_id=trade_id,
+                    wait_time=result_wait_s,
+                )
+
+                if callable(self._on_trade_result):
+                    from datetime import datetime
+
+                    placed_at = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+                    try:
+                        self._on_trade_result(
+                            trade_id=trade_id,
+                            symbol=self.symbol,
+                            timeframe=self.timeframe,
+                            signal_at=None,
+                            placed_at=placed_at,
+                            direction=status,
+                            stake=float(stake),
+                            percent=int(pct),
+                            profit=(
+                                None if profit is None else float(profit)
+                            ),
+                            account_mode=None,
+                            indicator=None,
+                        )
+                    except Exception:
+                        pass
+
+                if profit is None:
+                    log(
+                        f"[{self.symbol}] ⚠ Результат неизвестен — считаем как убыточный."
+                    )
+                    profit = -float(stake)
+
+                log(
+                    f"[{self.symbol}] Сделка {trade_number}: {'ПРИБЫЛЬ' if profit > 0 else 'УБЫТОК'} {profit:.2f}"
+                )
+
+                total_profit += profit
+
+                if profit > 0:
+                    remaining = base - total_profit
+                    if remaining <= 0:
+                        stake = base
+                    else:
+                        needed = remaining / (pct / 100.0)
+                        stake = max(base, min(stake + base, needed))
+                else:
+                    stake = max(base, stake)
+
+                trade_number += 1
+                self._status("ожидание сигнала")
+
+            series_left -= 1
+            log(
+                f"[{self.symbol}] Серия завершена. Осталось повторов: {series_left}"
+            )
+
+        self._running = False
+        self._status("завершен")
+        log(f"[{self.symbol}] Завершение стратегии.")


### PR DESCRIPTION
## Summary
- implement asynchronous Oscar Grind strategy with configurable parameters
- add settings dialog and register it in GUI
- expose Oscar Grind strategy option in main window

## Testing
- `python -m py_compile strategies/oscar_grind.py gui/settings_oscar_grind.py gui/settings_factory.py gui/main_window.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb4fe947c832291fcdf05781cec5c