### PR TITLE
feat: allow martingale with all symbols and timeframes

### DIFF
--- a/core/signal_waiter.py
+++ b/core/signal_waiter.py
@@ -44,6 +44,9 @@ class _State:
     )
     tf_sec: Optional[int] = None  # длительность TF в секундах (если удалось распарсить)
     last_indicator: Optional[str] = None  # ИМЯ индикатора источника последнего сигнала
+    # для wildcard-ожидателей запоминаем исходный символ/таймфрейм
+    last_symbol: Optional[str] = None
+    last_timeframe: Optional[str] = None
 
 
 _states: Dict[tuple[str, str], _State] = defaultdict(_State)
@@ -51,6 +54,10 @@ _states: Dict[tuple[str, str], _State] = defaultdict(_State)
 
 def _key(symbol: str, timeframe: str) -> tuple[str, str]:
     return (str(symbol).upper(), str(timeframe).upper())
+
+
+ANY_SYMBOL = "*"
+ANY_TIMEFRAME = "*"
 
 
 # --- public api ------------------------------------------------------
@@ -69,23 +76,30 @@ def push_signal(
     Любой приход (включая None) повышает версию и будит всех ожидающих.
     Также запоминаем момент прихода (monotonic), длительность TF и имя индикатора.
     """
-    st = _states[_key(symbol, timeframe)]
+    keys = {
+        _key(symbol, timeframe),
+        _key(ANY_SYMBOL, timeframe),
+        _key(symbol, ANY_TIMEFRAME),
+        _key(ANY_SYMBOL, ANY_TIMEFRAME),
+    }
 
-    async def _update_and_notify():
+    async def _update_and_notify(st: _State):
         async with st.cond:
             st.version += 1
             st.value = direction if direction in (1, 2) else None
             st.last_monotonic = asyncio.get_running_loop().time()
-            # запомним tf_sec один раз (или обновим, если распознали)
             sec = _tf_to_seconds(timeframe)
             if sec:
                 st.tf_sec = sec
-            # сохраняем индикатор, если пришёл
             if indicator is not None:
                 st.last_indicator = indicator
+            st.last_symbol = symbol
+            st.last_timeframe = timeframe
             st.cond.notify_all()
 
-    asyncio.get_running_loop().create_task(_update_and_notify())
+    loop = asyncio.get_running_loop()
+    for k in keys:
+        loop.create_task(_update_and_notify(_states[k]))
 
 
 async def _maybe_await(func: Callable[[], Awaitable[None] | None]) -> None:
@@ -109,7 +123,7 @@ async def wait_for_signal_versioned(
     # Детектор задержки следующего прогноза:
     grace_delay_sec: float = 5.0,
     on_delay: Optional[Callable[[float], None]] = None,  # callback(delay_seconds)
-    # --- новое: вернуть вместе с direction/version ещё и meta (indicator, tf_sec) ---
+    # --- новое: вернуть вместе с direction/version ещё и meta (indicator, tf_sec, symbol, timeframe) ---
     include_meta: bool = False,
 ) -> Tuple[int, int] | Tuple[int, int, Dict[str, Optional[str | int | float]]]:
     """
@@ -118,7 +132,7 @@ async def wait_for_signal_versioned(
     По умолчанию возвращает (direction, version), где direction ∈ {1,2}.
 
     Если include_meta=True — вернёт (direction, version, meta),
-    где meta = {"indicator": str|None, "tf_sec": int|None}.
+    где meta = {"indicator": str|None, "tf_sec": int|None, "symbol": str|None, "timeframe": str|None}.
     """
     st = _states[_key(symbol, timeframe)]
     start = asyncio.get_running_loop().time()
@@ -183,6 +197,8 @@ async def wait_for_signal_versioned(
                 meta = {
                     "indicator": st.last_indicator,
                     "tf_sec": st.tf_sec,
+                    "symbol": st.last_symbol,
+                    "timeframe": st.last_timeframe,
                 }
                 st.value = None  # сигнал больше не хранится
                 return int(direction), int(ver), meta

--- a/gui/bot_add_dialog.py
+++ b/gui/bot_add_dialog.py
@@ -5,7 +5,6 @@ from PyQt6.QtWidgets import (
     QDialogButtonBox,
     QLabel,
     QLineEdit,
-    QMessageBox,
 )
 
 ALL_SYMBOLS_LABEL = "Все валютные пары"
@@ -86,22 +85,7 @@ class AddBotDialog(QDialog):
         self.on_strategy_change()
 
     def on_strategy_change(self, *_):
-        key = self.selected_strategy
-        is_martingale = key == "martingale"
-
-        # disable "all" options for Martingale
-        sym_item = self.symbol_combo.model().item(0)
-        tf_item = self.tf_combo.model().item(0)
-        if sym_item:
-            sym_item.setEnabled(not is_martingale)
-        if tf_item:
-            tf_item.setEnabled(not is_martingale)
-
-        if is_martingale:
-            if self.symbol_combo.currentIndex() == 0 and self.symbol_combo.count() > 1:
-                self.symbol_combo.setCurrentIndex(1)
-            if self.tf_combo.currentIndex() == 0 and self.tf_combo.count() > 1:
-                self.tf_combo.setCurrentIndex(1)
+        pass
 
     @property
     def selected_symbol(self):
@@ -119,14 +103,4 @@ class AddBotDialog(QDialog):
         return self.selected_symbol, self.selected_strategy
 
     def accept(self):
-        if self.selected_strategy == "martingale" and (
-            self.selected_symbol == ALL_SYMBOLS_LABEL
-            or self.selected_timeframe == ALL_TF_LABEL
-        ):
-            QMessageBox.warning(
-                self,
-                "Ошибка",
-                "Стратегия 'Мартингейл' работает только с одной валютной парой и таймфреймом.",
-            )
-            return
         super().accept()

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -55,9 +55,10 @@ def _minutes_from_timeframe(tf: str) -> int:
 
 class MartingaleStrategy(StrategyBase):
     """
-    Мартингейл — работает ТОЛЬКО по одной паре и ОДНОМУ таймфрейму.
-    Если в UI выбраны «Все валютные пары»/«Все таймфреймы», мы корректно
-    приводим к одиночным (символ из kwargs и TF=M1) и пишем предупреждение в лог.
+    Мартингейл — серия ставок после каждого сигнала.
+    При выборе параметров "Все валютные пары"/"Все таймфреймы" стратегия
+    будет ожидать сигнал по любой паре/таймфрейму и выполнять серию для
+    полученных значений.
     """
 
     def __init__(
@@ -76,37 +77,37 @@ class MartingaleStrategy(StrategyBase):
         if params:
             p.update(params)
 
-        # Нормализация «все» → одиночные
         _symbol = (symbol or "").strip()
         _tf = (timeframe or "").strip().upper()
-        if _symbol == ALL_SYMBOLS_LABEL:
-            _symbol = params.get("force_symbol", "") or "EUR/USD"
-        if _tf == ALL_TF_LABEL:
-            _tf = "M1"
+        self._use_any_symbol = _symbol == ALL_SYMBOLS_LABEL
+        self._use_any_timeframe = _tf == ALL_TF_LABEL
+
+        cur_symbol = "*" if self._use_any_symbol else _symbol
+        cur_tf = "*" if self._use_any_timeframe else _tf
 
         super().__init__(
             session=http_client,
             user_id=user_id,
             user_hash=user_hash,
-            symbol=_symbol,
+            symbol=cur_symbol,
             log_callback=log_callback,
             **p,
         )
 
         self.http_client = http_client
-        self.timeframe = _tf or self.params.get("timeframe", "M1")
+        self.timeframe = cur_tf or self.params.get("timeframe", "M1")
         self.params["timeframe"] = self.timeframe
 
         raw_minutes = int(
             self.params.get("minutes", _minutes_from_timeframe(self.timeframe))
         )
-        norm = normalize_sprint(self.symbol, raw_minutes)
+        norm = normalize_sprint(cur_symbol, raw_minutes)
         if norm is None:
             fallback = _minutes_from_timeframe(self.timeframe)
-            norm = normalize_sprint(self.symbol, fallback) or fallback
+            norm = normalize_sprint(cur_symbol, fallback) or fallback
             if self.log:
                 self.log(
-                    f"[{self.symbol}] ⚠ Минуты {raw_minutes} недопустимы. Использую {norm}."
+                    f"[{cur_symbol}] ⚠ Минуты {raw_minutes} недопустимы. Использую {norm}."
                 )
         self._trade_minutes = int(norm)
         self.params["minutes"] = self._trade_minutes
@@ -144,13 +145,6 @@ class MartingaleStrategy(StrategyBase):
         self._running = True
         log = self.log or (lambda s: None)
 
-        # Подсказка, если кто-то пытался запустить «на всех»
-        if self.symbol == ALL_SYMBOLS_LABEL or self.timeframe == ALL_TF_LABEL:
-            log(
-                "⚠ Мартингейл поддерживает только одну валютную пару и один таймфрейм. "
-                "Привожу к одиночным параметрам (TF=M1)."
-            )
-
         try:
             self._anchor_is_demo = await is_demo_account(self.http_client)
             mode_txt = "ДЕМО" if self._anchor_is_demo else "РЕАЛ"
@@ -179,18 +173,27 @@ class MartingaleStrategy(StrategyBase):
             return
 
         try:
-            st = peek_signal_state(self.symbol, self.timeframe)
-            self._last_signal_ver = st.get("version", 0) or 0
-            if self.log:
-                self.log(
-                    f"[{self.symbol}] Заякорена версия сигнала: v{self._last_signal_ver}"
-                )
+            if self.symbol != "*" and self.timeframe != "*":
+                st = peek_signal_state(self.symbol, self.timeframe)
+                self._last_signal_ver = st.get("version", 0) or 0
+                if self.log:
+                    self.log(
+                        f"[{self.symbol}] Заякорена версия сигнала: v{self._last_signal_ver}"
+                    )
+            else:
+                self._last_signal_ver = 0
         except Exception:
             self._last_signal_ver = 0
 
         while self._running and series_left > 0:
             self._last_signal_at_str = None
             await self._pause_point()
+
+            if self._use_any_symbol:
+                self.symbol = "*"
+            if self._use_any_timeframe:
+                self.timeframe = "*"
+                self.params["timeframe"] = self.timeframe
 
             if not await self._ensure_anchor_currency():
                 continue
@@ -494,7 +497,27 @@ class MartingaleStrategy(StrategyBase):
         direction, ver, meta = await self.wait_cancellable(coro, timeout=timeout)
         self._last_signal_ver = ver
         self._last_indicator = (meta or {}).get("indicator") or "-"
-        # фиксируем момент прихода сигнала — для таблицы "Время получения сигнала"
+
+        sig_symbol = (meta or {}).get("symbol") or self.symbol
+        sig_tf = (meta or {}).get("timeframe") or self.timeframe
+        if self._use_any_symbol:
+            self.symbol = sig_symbol
+        if self._use_any_timeframe:
+            self.timeframe = sig_tf
+            self.params["timeframe"] = self.timeframe
+        if self._use_any_symbol or self._use_any_timeframe:
+            raw_minutes = _minutes_from_timeframe(self.timeframe)
+            norm = normalize_sprint(self.symbol, raw_minutes)
+            if norm is None:
+                fallback = raw_minutes
+                norm = normalize_sprint(self.symbol, fallback) or fallback
+                if self.log:
+                    self.log(
+                        f"[{self.symbol}] ⚠ Минуты {raw_minutes} недопустимы. Использую {norm}."
+                    )
+            self._trade_minutes = int(norm)
+            self.params["minutes"] = self._trade_minutes
+
         from datetime import datetime
 
         self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
@@ -523,14 +546,10 @@ class MartingaleStrategy(StrategyBase):
 
         if "timeframe" in params:
             tf = str(params["timeframe"]).strip().upper()
-            if tf == ALL_TF_LABEL:
-                tf = "M1"
-                if self.log:
-                    self.log(
-                        f"[{self.symbol}] ⚠ Мартингейл не поддерживает «Все таймфреймы». Установлено M1."
-                    )
-            self.timeframe = tf
-            if "minutes" not in params:
+            self._use_any_timeframe = tf in (ALL_TF_LABEL, "*")
+            self.timeframe = "*" if self._use_any_timeframe else tf
+            self.params["timeframe"] = self.timeframe
+            if self.timeframe != "*" and "minutes" not in params:
                 self._trade_minutes = _minutes_from_timeframe(self.timeframe)
 
         if "account_currency" in params:


### PR DESCRIPTION
## Summary
- allow selecting all symbols and timeframes for Martingale strategy
- handle wildcard signals in waiters and strategy logic
- simplify bot creation dialog without Martingale restrictions

## Testing
- `python -m py_compile core/signal_waiter.py strategies/martingale.py gui/bot_add_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_68ade927e4a48322811c698bcd146f76