### PR TITLE
feat: configurable application font

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,7 @@
     "app_name": "Intradevor",
     "app_version": "1.0.0",
     "domain": "intrade27.bar",
-    "ws_url": "ws://192.168.56.101:8080"
+    "ws_url": "ws://192.168.56.101:8080",
+    "font_family": "",
+    "font_size": 0
 }

--- a/core/config.py
+++ b/core/config.py
@@ -16,6 +16,15 @@ base_url: str = f"https://{domain}"
 
 ws_url: str = os.getenv("WS_URL", "ws://192.168.56.101:8080")
 
+# Параметры шрифта приложения
+FONT_FAMILY: str | None = os.getenv("FONT_FAMILY")
+try:
+    FONT_SIZE: int | None = (
+        int(os.getenv("FONT_SIZE")) if os.getenv("FONT_SIZE") else None
+    )
+except ValueError:
+    FONT_SIZE = None
+
 
 def _read_json(path: str) -> Dict[str, Any]:
     if not os.path.exists(path):
@@ -45,7 +54,7 @@ def load_config() -> None:
       3) Значения по умолчанию
     Если файла нет — он будет создан с текущими значениями (дефолты/окружение).
     """
-    global APP_NAME, APP_VERSION, domain, base_url, ws_url
+    global APP_NAME, APP_VERSION, domain, base_url, ws_url, FONT_FAMILY, FONT_SIZE
 
     if not os.path.exists(_CONFIG_FILE):
         # создаём файл с текущими (дефолт/окружение) значениями
@@ -67,6 +76,14 @@ def load_config() -> None:
     if "WS_URL" not in os.environ:
         ws_url = data.get("ws_url", ws_url)
 
+    if "FONT_FAMILY" not in os.environ:
+        FONT_FAMILY = data.get("font_family", FONT_FAMILY)
+    if "FONT_SIZE" not in os.environ:
+        try:
+            FONT_SIZE = int(data.get("font_size", FONT_SIZE)) if data.get("font_size") is not None else FONT_SIZE
+        except (TypeError, ValueError):
+            pass
+
     base_url = f"https://{domain}"
 
 
@@ -82,6 +99,8 @@ def save_config() -> None:
             "app_version": APP_VERSION,
             "domain": domain,
             "ws_url": ws_url,
+            "font_family": FONT_FAMILY,
+            "font_size": FONT_SIZE,
         }
     )
     _write_json(_CONFIG_FILE, data)
@@ -115,6 +134,14 @@ def get_app_version() -> str:
     return APP_VERSION
 
 
+def get_font_family() -> str | None:
+    return FONT_FAMILY
+
+
+def get_font_size() -> int | None:
+    return FONT_SIZE
+
+
 # ===== Опционально: апдейтеры из кода =====
 def set_app_name(name: str) -> None:
     global APP_NAME
@@ -124,3 +151,13 @@ def set_app_name(name: str) -> None:
 def set_app_version(ver: str) -> None:
     global APP_VERSION
     APP_VERSION = (ver or "").strip() or APP_VERSION
+
+
+def set_font_family(name: str | None) -> None:
+    global FONT_FAMILY
+    FONT_FAMILY = name
+
+
+def set_font_size(size: int | None) -> None:
+    global FONT_SIZE
+    FONT_SIZE = size

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -10,6 +10,9 @@ from PyQt6.QtWidgets import (
     QTableWidgetItem,
     QHeaderView,
     QMessageBox,
+    QMenuBar,
+    QApplication,
+    QFontDialog,
 )
 from PyQt6.QtGui import QTextCursor, QColor, QBrush
 from PyQt6.QtCore import Qt, QTimer
@@ -19,6 +22,7 @@ import asyncio
 
 from core.money import format_money
 from core.logger import ts
+from core import config
 
 from gui.bot_add_dialog import AddBotDialog, ALL_SYMBOLS_LABEL
 from gui.risk_dialog import RiskDialog
@@ -44,6 +48,11 @@ from strategies.oscar_grind import OscarGrindStrategy
 class MainWindow(QWidget):
     def __init__(self):
         super().__init__()
+
+        # === Меню ===
+        self.menu_bar = QMenuBar(self)
+        font_menu = self.menu_bar.addMenu("Шрифт")
+        font_menu.addAction("Выбрать...", self._choose_font)
 
         # === имя/версия приложения ===
         try:
@@ -239,6 +248,7 @@ class MainWindow(QWidget):
         self.trades_table.setFocusPolicy(Qt.FocusPolicy.NoFocus)
 
         layout = QVBoxLayout()
+        layout.setMenuBar(self.menu_bar)
         layout.addLayout(top_layout)
         layout.addWidget(self.change_currency_button)
         layout.addWidget(self.set_risk_button)
@@ -320,6 +330,16 @@ class MainWindow(QWidget):
         cur.movePosition(QTextCursor.MoveOperation.Start)  # курсор в начало
         self.signal_log.setTextCursor(cur)
         self.signal_log.insertPlainText(s)  # вставляем новую строку сверху
+
+    def _choose_font(self):
+        current_font = QApplication.instance().font()
+        font, ok = QFontDialog.getFont(current_font, self, "Выбор шрифта")
+        if not ok:
+            return
+        QApplication.instance().setFont(font)
+        config.set_font_family(font.family())
+        config.set_font_size(font.pointSize())
+        config.save_config()
 
     # -------------------- bots --------------------
     def show_add_bot_dialog(self):

--- a/main.py
+++ b/main.py
@@ -1,14 +1,27 @@
 import sys
+import asyncio
 from PyQt6.QtWidgets import QApplication
 from qasync import QEventLoop
-import asyncio
+
 from gui.main_window import MainWindow
+from core import config
 
 # from core.ws_server import run_server
 
 
 def run_gui():
     app = QApplication(sys.argv)
+
+    # Устанавливаем шрифт из config, если задан
+    font_family = config.get_font_family()
+    font_size = config.get_font_size()
+    if font_family or font_size:
+        font = app.font()  # текущий системный шрифт
+        if font_family:
+            font.setFamily(font_family)
+        if font_size:
+            font.setPointSize(font_size)
+        app.setFont(font)
 
     loop = QEventLoop(app)
     asyncio.set_event_loop(loop)


### PR DESCRIPTION
## Summary
- allow choosing application font and size from menu bar
- persist chosen font to config.json and apply on startup

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeb8292838832299c2c60a44a05189