### PR TITLE
Add classic Oscar Grind strategy and rename existing

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -42,7 +42,8 @@ from core.ws_client import listen_to_signals
 from core.bot_manager import BotManager
 from core.bot import Bot
 from strategies.martingale import MartingaleStrategy
-from strategies.oscar_grind import OscarGrindStrategy
+from strategies.oscar_grind_1 import OscarGrind1Strategy
+from strategies.oscar_grind_2 import OscarGrind2Strategy
 
 
 class MainWindow(QWidget):
@@ -92,11 +93,13 @@ class MainWindow(QWidget):
         ]
         self.available_strategies = {
             "martingale": MartingaleStrategy,
-            "oscar_grind": OscarGrindStrategy,
+            "oscar_grind_1": OscarGrind1Strategy,
+            "oscar_grind_2": OscarGrind2Strategy,
         }
         self.strategy_labels = {
             "martingale": "Мартингейл",
-            "oscar_grind": "Оскар Грайнд",
+            "oscar_grind_1": "Оскар Грайнд 1",
+            "oscar_grind_2": "Оскар Грайнд 2",
         }
 
         self.bot_ever_started = defaultdict(bool)

--- a/gui/settings_factory.py
+++ b/gui/settings_factory.py
@@ -1,13 +1,15 @@
 from typing import Type, Dict
 from PyQt6.QtWidgets import QDialog
 from strategies.martingale import MartingaleStrategy
-from strategies.oscar_grind import OscarGrindStrategy
+from strategies.oscar_grind_1 import OscarGrind1Strategy
+from strategies.oscar_grind_2 import OscarGrind2Strategy
 from gui.settings_martingale import MartingaleSettingsDialog
 from gui.settings_oscar_grind import OscarGrindSettingsDialog
 
 _registry: Dict[Type, Type[QDialog]] = {
     MartingaleStrategy: MartingaleSettingsDialog,
-    OscarGrindStrategy: OscarGrindSettingsDialog,
+    OscarGrind1Strategy: OscarGrindSettingsDialog,
+    OscarGrind2Strategy: OscarGrindSettingsDialog,
 }
 
 

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -134,7 +134,7 @@ class StrategyControlDialog(QDialog):
         strategy_key = str(self.bot.strategy_kwargs.get("strategy_key", "")).lower()
         self.strategy_key = strategy_key
 
-        if strategy_key == "oscar_grind":
+        if strategy_key in ("oscar_grind_1", "oscar_grind_2"):
             self.minutes = QSpinBox()
             self.minutes.setRange(5 if symbol == "BTCUSDT" else 1, 500)
             self.minutes.setValue(default_minutes)
@@ -361,7 +361,7 @@ class StrategyControlDialog(QDialog):
             box.open()
             return
 
-        if getattr(self, "strategy_key", "") == "oscar_grind":
+        if getattr(self, "strategy_key", "") in ("oscar_grind_1", "oscar_grind_2"):
             new_params = {
                 "base_investment": self.base_investment.value(),
                 "target_profit": self.target_profit.value(),

--- a/strategies/oscar_grind_1.py
+++ b/strategies/oscar_grind_1.py
@@ -1,0 +1,48 @@
+# strategies/oscar_grind_1.py
+from __future__ import annotations
+
+from strategies.oscar_grind_2 import OscarGrind2Strategy
+
+
+class OscarGrind1Strategy(OscarGrind2Strategy):
+    """Классическая стратегия Oscar Grind.
+
+    В этом варианте после выигрыша следующая ставка всегда
+    увеличивается на величину базовой ставки (unit) без ограничения
+    по достижению целевой прибыли серии.
+    """
+
+    def _next_stake(
+        self,
+        *,
+        outcome: str,
+        stake: float,
+        base_unit: float,
+        pct: float,
+        need: float,
+        profit: float,
+        cum_profit: float,
+        target_profit: float,
+        log,
+    ) -> float:
+        if outcome == "win":
+            next_stake = stake + base_unit
+            log(
+                f"[{self.symbol}] ✅ WIN: profit={profit:.2f}. "
+                f"Накоплено {cum_profit:.2f}/{target_profit:.2f}. "
+                f"Следующая ставка = stake+unit → {next_stake:.2f}"
+            )
+        else:
+            next_stake = stake
+            if outcome == "refund":
+                log(
+                    f"[{self.symbol}] ↩️ REFUND: ставка возвращена. "
+                    f"Следующая ставка остаётся {next_stake:.2f}."
+                )
+            else:
+                log(
+                    f"[{self.symbol}] ❌ LOSS: profit={profit:.2f}. "
+                    f"Следующая ставка остаётся {next_stake:.2f}."
+                )
+        return float(next_stake)
+

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -1,4 +1,4 @@
-# strategies/oscar_grind.py
+# strategies/oscar_grind_2.py
 from __future__ import annotations
 
 import asyncio
@@ -47,14 +47,12 @@ DEFAULTS = {
 }
 
 
-class OscarGrindStrategy(StrategyBase):
-    """
-    Oscar Grind (позитивная прогрессия):
-    - Цель серии — получить фиксированный профит (target_profit), по умолчанию 1 «единицу» (base_investment).
-    - На проигрыше следующая ставка НЕ увеличивается (остаётся прежней).
-    - На выигрыше следующая ставка увеличивается на 1 «единицу», но НЕ больше, чем необходимо,
-      чтобы при следующем выигрыше достичь целевой прибыли серии.
-    - Серия заканчивается, когда cumulative_profit >= target_profit, либо по лимиту шагов.
+class OscarGrind2Strategy(StrategyBase):
+    """Oscar Grind 2 (позитивная прогрессия).
+
+    Вариант стратегии, в котором после выигрыша следующая ставка
+    увеличивается на 1 «единицу», но не больше, чем необходимо для
+    достижения целевой прибыли серии одним следующим выигрышем.
     """
 
     def __init__(
@@ -440,34 +438,18 @@ class OscarGrindStrategy(StrategyBase):
                     break
 
                 # Вычислим следующую ставку по правилам Oscar Grind
-                k = pct / 100.0
-                # Сколько ещё надо добрать профита
                 need = max(0.0, target_profit - cum_profit)
-
-                if outcome == "win":
-                    # Выигрыш → увеличиваем на 1 unit, но не выше, чем нужно для достижения цели за один следующий WIN
-                    # Требуемая ставка для достижения цели одной следующей победой:
-                    # need = next_stake * k  →  next_stake_req = ceil(need / k)
-                    next_req = math.ceil(need / k) if k > 0 else stake
-                    next_stake = max(base_unit, min(stake + base_unit, float(next_req)))
-                    log(
-                        f"[{self.symbol}] ✅ WIN: profit={profit:.2f}. "
-                        f"Накоплено {cum_profit:.2f}/{target_profit:.2f}. "
-                        f"Следующая ставка = min(stake+unit, req) → {stake + base_unit:.2f} / {next_req:.2f} = {next_stake:.2f}"
-                    )
-                else:
-                    # Проигрыш или возврат → ставка остаётся прежней
-                    next_stake = stake
-                    if outcome == "refund":
-                        log(
-                            f"[{self.symbol}] ↩️ REFUND: ставка возвращена. "
-                            f"Следующая ставка остаётся {next_stake:.2f}."
-                        )
-                    else:
-                        log(
-                            f"[{self.symbol}] ❌ LOSS: profit={0.0 if profit is None else profit:.2f}. "
-                            f"Следующая ставка остаётся {next_stake:.2f}."
-                        )
+                next_stake = self._next_stake(
+                    outcome=outcome,
+                    stake=stake,
+                    base_unit=base_unit,
+                    pct=pct,
+                    need=need,
+                    profit=0.0 if profit is None else float(profit),
+                    cum_profit=cum_profit,
+                    target_profit=target_profit,
+                    log=log,
+                )
 
                 # Переходим к следующему шагу
                 stake = float(next_stake)
@@ -492,6 +474,42 @@ class OscarGrindStrategy(StrategyBase):
 
         self._running = False
         (self.log or (lambda s: None))(f"[{self.symbol}] Завершение стратегии.")
+
+    def _next_stake(
+        self,
+        *,
+        outcome: str,
+        stake: float,
+        base_unit: float,
+        pct: float,
+        need: float,
+        profit: float,
+        cum_profit: float,
+        target_profit: float,
+        log,
+    ) -> float:
+        k = pct / 100.0
+        if outcome == "win":
+            next_req = math.ceil(need / k) if k > 0 else stake
+            next_stake = max(base_unit, min(stake + base_unit, float(next_req)))
+            log(
+                f"[{self.symbol}] ✅ WIN: profit={profit:.2f}. "
+                f"Накоплено {cum_profit:.2f}/{target_profit:.2f}. "
+                f"Следующая ставка = min(stake+unit, req) → {stake + base_unit:.2f} / {next_req:.2f} = {next_stake:.2f}"
+            )
+        else:
+            next_stake = stake
+            if outcome == "refund":
+                log(
+                    f"[{self.symbol}] ↩️ REFUND: ставка возвращена. "
+                    f"Следующая ставка остаётся {next_stake:.2f}."
+                )
+            else:
+                log(
+                    f"[{self.symbol}] ❌ LOSS: profit={profit:.2f}. "
+                    f"Следующая ставка остаётся {next_stake:.2f}."
+                )
+        return float(next_stake)
 
     async def _ensure_anchor_currency(self) -> bool:
         try:


### PR DESCRIPTION
## Summary
- rename existing Oscar Grind strategy to Oscar Grind 2
- implement classic Oscar Grind 1 increasing stake by base unit after win
- update GUI and settings factory to expose both strategies

## Testing
- `python -m py_compile strategies/oscar_grind_2.py strategies/oscar_grind_1.py gui/main_window.py gui/settings_factory.py gui/strategy_control_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0aa333348322a48301b5e0e872ab