### PR TITLE
Fix duplicate trade records when multiple strategies run

### DIFF
--- a/core/intrade_api.py
+++ b/core/intrade_api.py
@@ -223,10 +223,18 @@ def place_trade(
     }
     r = session.post(TRADE_URL, data=payload)
     soup = BeautifulSoup(r.text, "html.parser")
-    trade = soup.find("tr", class_="trade_graph_tick")
-    if trade and trade.has_attr("data-id"):
-        return trade["data-id"]
-    return None
+
+    # На странице может присутствовать несколько открытых сделок. Метод
+    # ``find`` возвращал первую запись, из-за чего несколько стратегий могли
+    # получить одинаковый идентификатор сделки. Выберем строку с максимальным
+    # значением ``data-id`` — это и будет недавно созданная сделка.
+    trades = [
+        tr for tr in soup.find_all("tr", class_="trade_graph_tick") if tr.has_attr("data-id")
+    ]
+    if not trades:
+        return None
+    trade = max(trades, key=lambda tr: int(tr["data-id"]))
+    return trade["data-id"]
 
 
 async def check_trade_result(session, user_id, user_hash, trade_id, wait_time=60.0):

--- a/core/intrade_api_async.py
+++ b/core/intrade_api_async.py
@@ -166,10 +166,19 @@ async def place_trade(
     }
     html = await client.post(PATH_TRADE, data=payload, expect_json=False)
     soup = BeautifulSoup(html, "html.parser")
-    trade = soup.find("tr", class_="trade_graph_tick")
-    if trade and trade.has_attr("data-id"):
-        return trade["data-id"]
-    return None
+
+    # Ответ может содержать несколько открытых сделок. Ранее брался первый
+    # <tr class="trade_graph_tick">, что приводило к возврату одного и того же
+    # идентификатора при одновременной работе нескольких стратегий. Чтобы
+    # гарантированно получить именно последнюю созданную сделку, выбираем
+    # запись с максимальным ``data-id``.
+    trades = [
+        tr for tr in soup.find_all("tr", class_="trade_graph_tick") if tr.has_attr("data-id")
+    ]
+    if not trades:
+        return None
+    trade = max(trades, key=lambda tr: int(tr["data-id"]))
+    return trade["data-id"]
 
 
 async def check_trade_result(


### PR DESCRIPTION
## Summary
- ensure `place_trade` returns newest trade id by selecting row with max data-id
- apply logic to async and sync APIs

## Testing
- `python -m py_compile core/intrade_api.py core/intrade_api_async.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0fa9e89c8322858be09138b7c732