### PR TITLE
Fix missing signals for concurrent bots

### DIFF
--- a/core/signal_waiter.py
+++ b/core/signal_waiter.py
@@ -200,9 +200,7 @@ async def wait_for_signal_versioned(
                     "symbol": st.last_symbol,
                     "timeframe": st.last_timeframe,
                 }
-                st.value = None  # сигнал больше не хранится
                 return int(direction), int(ver), meta
-            st.value = None  # сигнал больше не хранится
             return int(direction), int(ver)
         # иначе ждём следующего уведомления
 


### PR DESCRIPTION
## Summary
- keep last signal available until a new one arrives so all waiting bots receive it

## Testing
- `python - <<'PY'
import asyncio
from core.signal_waiter import wait_for_signal_versioned, push_signal

async def bot(name):
    direction, ver = await wait_for_signal_versioned("EURUSD", "M1")
    print(name, direction, ver)

async def main():
    t1 = asyncio.create_task(bot('bot1'))
    t2 = asyncio.create_task(bot('bot2'))
    await asyncio.sleep(0.1)
    push_signal("EURUSD", "M1", 1)
    await asyncio.gather(t1,t2)

asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af11eaaebc832287abc1ea144f24fa