### PR TITLE
Fix timer updates for multiple pending trades

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -725,11 +725,16 @@ class MainWindow(QWidget):
 
             def _tick():
                 left = expected_end_ts - _now()
-                # если строка пропала — стоп
-                if row >= self.trades_table.rowCount():
+                info = self.pending_trades.get(trade_id)
+                if not info:
                     timer.stop()
                     return
-                item = self.trades_table.item(row, 10)  # P/L
+                cur_row = info.get("row")
+                # если строка пропала — стоп
+                if not isinstance(cur_row, int) or cur_row >= self.trades_table.rowCount():
+                    timer.stop()
+                    return
+                item = self.trades_table.item(cur_row, 10)  # P/L
                 if item:
                     item.setText(f"Ожидание ({_fmt_left(left)})")
                 if left <= 0:

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -489,10 +489,15 @@ class StrategyControlDialog(QDialog):
 
         def _tick():
             left = expected_end_ts - _now()
-            if row >= self.trades_table.rowCount():
+            info = self._pending_rows.get(trade_id)
+            if not info:
                 timer.stop()
                 return
-            item = self.trades_table.item(row, 9)
+            cur_row = info.get("row")
+            if not isinstance(cur_row, int) or cur_row >= self.trades_table.rowCount():
+                timer.stop()
+                return
+            item = self.trades_table.item(cur_row, 9)
             if item:
                 item.setText(f"Ожидание ({_fmt_left(left)})")
             if left <= 0:


### PR DESCRIPTION
## Summary
- ensure pending-trade timers look up their current row so countdowns keep updating even when new trades are inserted
- apply same fix for strategy control dialog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af2ac771348322b6efa90cd46b75d4