### PR TITLE
Improve table layout, defaults, and formatting

### DIFF
--- a/core/intrade_api.py
+++ b/core/intrade_api.py
@@ -7,6 +7,7 @@ from core.policy import (
     clamp_stake,
     normalize_sprint,
 )
+from core.money import format_amount
 
 BALANCE_URL = f"{config.base_url}/balance.php"
 TRADE_URL = f"{config.base_url}/ajax5_new.php"
@@ -200,7 +201,10 @@ def place_trade(
 
     clamped = clamp_stake(account_ccy, inv)
     if clamped != inv:
-        msg = f"[{option}] ℹ️ Ставка приведена к лимитам {account_ccy}: {clamped:.2f}"
+        msg = (
+            f"[{option}] ℹ️ Ставка приведена к лимитам {account_ccy}: "
+            f"{format_amount(clamped)}"
+        )
         if strict:
             if on_log:
                 on_log(f"[{option}] 🚫 Ставка вне лимитов {account_ccy}. {msg}")

--- a/core/intrade_api_async.py
+++ b/core/intrade_api_async.py
@@ -8,6 +8,7 @@ from bs4 import BeautifulSoup
 
 from core.http_async import HttpClient
 from core.policy import DEFAULT_ACCOUNT_CCY, clamp_stake, normalize_sprint
+from core.money import format_amount
 from core.intrade_api import (
     _parse_balance_text,
 )  # переиспользуем точный парсер sync-версии
@@ -143,7 +144,10 @@ async def place_trade(
 
     clamped = clamp_stake(account_ccy, inv)
     if clamped != inv:
-        msg = f"[{option}] ℹ️ Ставка приведена к лимитам {account_ccy}: {clamped:.2f}"
+        msg = (
+            f"[{option}] ℹ️ Ставка приведена к лимитам {account_ccy}: "
+            f"{format_amount(clamped)}"
+        )
         if strict:
             if on_log:
                 on_log(f"[{option}] 🚫 Ставка вне лимитов {account_ccy}. {msg}")

--- a/core/money.py
+++ b/core/money.py
@@ -8,8 +8,16 @@ _SYMBOLS = {
 }
 
 
-def format_money(amount: float, code: str) -> str:
-    """1234.5, 'RUB' -> '1 234.50 ₽'; если код не знаем — '1 234.50 XXX'"""
-    s = f"{amount:,.2f}".replace(",", " ")
+def format_amount(amount: float, show_plus: bool = False) -> str:
+    """Возвращает строку с пробелами между тысячами и запятой в качестве разделителя."""
+    s = f"{amount:,.2f}".replace(",", " ").replace(".", ",")
+    if show_plus and amount > 0:
+        s = "+" + s
+    return s
+
+
+def format_money(amount: float, code: str, *, show_plus: bool = False) -> str:
+    """1234.5, 'RUB' -> '1 234,50 ₽'; если код не знаем — '1 234,50 XXX'"""
+    s = format_amount(amount, show_plus=show_plus)
     sym = _SYMBOLS.get(code.upper())
     return f"{s} {sym}" if sym else f"{s} {code.upper()}"

--- a/core/ws_client.py
+++ b/core/ws_client.py
@@ -122,9 +122,10 @@ async def listen_to_signals() -> None:
 
                     dt_naive = sig.timestamp.replace(tzinfo=None)
                     msg_dir = {1: "UP", 2: "DOWN", None: "none"}[sig.direction]
-                    _log(
-                        f"[WS] {sig.symbol} / {sig.timeframe}. Прогноз: {msg_dir} от {sig.indicator}. Время свечи: {dt_naive.strftime('%H:%M')}"
-                    )
+                    if msg_dir != "none":
+                        _log(
+                            f"[WS] {sig.symbol} / {sig.timeframe}. Прогноз: {msg_dir} от {sig.indicator}. Время свечи: {dt_naive.strftime('%H:%M')}"
+                        )
         except Exception as e:
             delay = min(30, 2 ** min(retry, 5))
             _log(f"[WS] Потеря соединения: {e}. Повтор через {delay}c")

--- a/gui/bot_add_dialog.py
+++ b/gui/bot_add_dialog.py
@@ -53,7 +53,7 @@ class AddBotDialog(QDialog):
         layout.addWidget(QLabel("Таймфрейм:"))
         self.tf_combo = QComboBox()
         self.tf_combo.addItems(TIMEFRAMES)
-        self.tf_combo.setCurrentText("M1")
+        self.tf_combo.setCurrentText(ALL_TF_LABEL)
         layout.addWidget(self.tf_combo)
 
         # Кнопки
@@ -66,6 +66,7 @@ class AddBotDialog(QDialog):
 
         self.setLayout(layout)
         self.on_strategy_change()
+        self.resize(self.sizeHint())
 
     def filter_symbols(self, text: str):
         self.symbol_combo.clear()

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -183,14 +183,7 @@ class MainWindow(QWidget):
             ]
         )
         hdr = self.bot_table.horizontalHeader()
-        hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(3, QHeaderView.ResizeMode.Stretch)
-        hdr.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(6, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(7, QHeaderView.ResizeMode.ResizeToContents)
+        hdr.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
         self.bot_table.setAlternatingRowColors(True)
         self.bot_table.setSortingEnabled(False)
         self.bot_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
@@ -234,18 +227,7 @@ class MainWindow(QWidget):
             ]
         )
         hdr = self.trades_table.horizontalHeader()
-        hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
-        hdr.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
-        hdr.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(6, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(7, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(8, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(9, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(10, QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setSectionResizeMode(11, QHeaderView.ResizeMode.ResizeToContents)
+        hdr.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
         self.trades_table.setAlternatingRowColors(True)
         # self.trades_table.setSortingEnabled(True)
         self.trades_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
@@ -266,6 +248,7 @@ class MainWindow(QWidget):
         layout.addWidget(QLabel("Сделки:"))
         layout.addWidget(self.trades_table)
         self.setLayout(layout)
+        self.resize(1200, 700)
 
         QTimer.singleShot(0, self.start_async_tasks)
 
@@ -922,9 +905,8 @@ class MainWindow(QWidget):
             v = float(value)
         except Exception:
             v = 0.0
-        sign = "+" if v > 1e-12 else ""
         ccy = getattr(self, "account_currency", "RUB")
-        return f"{sign}{v:.2f} {ccy}"
+        return format_money(v, ccy, show_plus=True)
 
     def _refresh_bot_rows_runtime(self):
         now = asyncio.get_running_loop().time()

--- a/gui/risk_dialog.py
+++ b/gui/risk_dialog.py
@@ -50,6 +50,7 @@ class RiskDialog(QDialog):
 
         form.addRow(buttons)
         self.setLayout(form)
+        self.adjustSize()
 
     def values(self) -> Tuple[int, int]:
         """

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -18,6 +18,7 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtGui import QColor, QBrush
 from PyQt6.QtCore import QTimer, Qt
+from core.money import format_amount
 from strategies.martingale import _minutes_from_timeframe
 from core.policy import normalize_sprint
 from core.money import format_money
@@ -92,22 +93,7 @@ class StrategyControlDialog(QDialog):
             ]
         )
         hdr = self.trades_table.horizontalHeader()
-        # PyQt6: используем QHeaderView.ResizeMode.*
-        hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)  # Время сигнала
-        hdr.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)  # Время ставки
-        hdr.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)  # Пара
-        hdr.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)  # ТФ
-        hdr.setSectionResizeMode(
-            4, QHeaderView.ResizeMode.ResizeToContents
-        )  # Индикатор
-        hdr.setSectionResizeMode(
-            5, QHeaderView.ResizeMode.ResizeToContents
-        )  # Направление
-        hdr.setSectionResizeMode(6, QHeaderView.ResizeMode.ResizeToContents)  # Ставка
-        hdr.setSectionResizeMode(7, QHeaderView.ResizeMode.ResizeToContents)  # Время
-        hdr.setSectionResizeMode(8, QHeaderView.ResizeMode.ResizeToContents)  # %
-        hdr.setSectionResizeMode(9, QHeaderView.ResizeMode.ResizeToContents)  # P/L
-        hdr.setSectionResizeMode(10, QHeaderView.ResizeMode.ResizeToContents)  # Счёт
+        hdr.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
         self.trades_table.setAlternatingRowColors(True)
         self.trades_table.setSortingEnabled(False)
         self.trades_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
@@ -259,6 +245,7 @@ class StrategyControlDialog(QDialog):
         layout = QVBoxLayout(self)
         layout.addWidget(header)
         layout.addWidget(top_split, stretch=1)
+        self.resize(1000, 600)
 
         # Таймер статуса/кнопок
         self.timer = QTimer(self)
@@ -392,7 +379,7 @@ class StrategyControlDialog(QDialog):
         formatted = []
         for k, v in new_params.items():
             if isinstance(v, float):
-                formatted.append(f"'{k}': {v:.2f}")
+                formatted.append(f"'{k}': {format_amount(v)}")
             else:
                 formatted.append(f"'{k}': {v}")
         self.log_edit.append(

--- a/gui/trades_table_widget.py
+++ b/gui/trades_table_widget.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from PyQt6.QtWidgets import QTableWidget, QTableWidgetItem, QHeaderView
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor, QBrush
+from core.money import format_amount
 
 
 class TradesTableWidget(QTableWidget):
@@ -44,10 +45,7 @@ class TradesTableWidget(QTableWidget):
         self.setHorizontalHeaderLabels(self.COLS)
 
         hdr = self.horizontalHeader()
-        hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)  # Время сигнала
-        hdr.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)  # Время ставки
-        for c in range(2, len(self.COLS)):
-            hdr.setSectionResizeMode(c, QHeaderView.ResizeMode.ResizeToContents)
+        hdr.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
 
         self.setAlternatingRowColors(True)
         self.setSortingEnabled(True)
@@ -84,7 +82,7 @@ class TradesTableWidget(QTableWidget):
             symbol,
             timeframe,
             dir_text,
-            f"{stake:.2f}",
+            format_amount(stake),
             f"{int(round(duration / 60))} мин",
             f"{percent}%",
             "ожидание…",
@@ -119,7 +117,7 @@ class TradesTableWidget(QTableWidget):
             pl_item.setText("неизв.")
             return
 
-        text = f"{profit:+.2f}"
+        text = format_amount(profit, show_plus=True)
         if currency_suffix:
             text += f" {currency_suffix}"
         pl_item.setText(text)

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -14,6 +14,7 @@ from core.intrade_api_async import (
 )
 from core.signal_waiter import wait_for_signal_versioned, peek_signal_state
 from strategies.base import StrategyBase
+from core.money import format_amount
 from core.policy import normalize_sprint
 
 ALL_SYMBOLS_LABEL = "Все валютные пары"
@@ -160,7 +161,7 @@ class MartingaleStrategy(StrategyBase):
                 self.http_client, self.user_id, self.user_hash
             )
             log(
-                f"[{self.symbol}] Баланс: {display} ({amount:.2f}), текущая валюта: {cur_ccy}, якорь: {self._anchor_ccy}"
+                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}, якорь: {self._anchor_ccy}"
             )
         except Exception as e:
             log(f"[{self.symbol}] ⚠ Не удалось получить баланс при старте: {e}")
@@ -212,7 +213,7 @@ class MartingaleStrategy(StrategyBase):
             min_balance = float(self.params.get("min_balance", DEFAULTS["min_balance"]))
             if bal < min_balance:
                 log(
-                    f"[{self.symbol}] ⛔ Баланс ниже минимума ({bal:.2f} < {min_balance:.2f}). Ожидание..."
+                    f"[{self.symbol}] ⛔ Баланс ниже минимума ({format_amount(bal)} < {format_amount(min_balance)}). Ожидание..."
                 )
                 await self.sleep(2.0)
                 continue
@@ -309,12 +310,12 @@ class MartingaleStrategy(StrategyBase):
                 )
                 if cur_balance is None or (cur_balance - stake) < min_floor:
                     log(
-                        f"[{self.symbol}] 🛑 Сделка {stake:.2f} {account_ccy} может опустить баланс ниже "
-                        f"{min_floor:.2f} {account_ccy}"
+                        f"[{self.symbol}] 🛑 Сделка {format_amount(stake)} {account_ccy} может опустить баланс ниже "
+                        f"{format_amount(min_floor)} {account_ccy}"
                         + (
                             ""
                             if cur_balance is None
-                            else f" (текущий {cur_balance:.2f} {account_ccy})"
+                            else f" (текущий {format_amount(cur_balance)} {account_ccy})"
                         )
                         + ". Останавливаю стратегию."
                     )
@@ -327,7 +328,7 @@ class MartingaleStrategy(StrategyBase):
                     continue
 
                 log(
-                    f"[{self.symbol}] step={step} stake={stake:.2f} min={self._trade_minutes} "
+                    f"[{self.symbol}] step={step} stake={format_amount(stake)} min={self._trade_minutes} "
                     f"side={'UP' if status == 1 else 'DOWN'} payout={pct}%"
                 )
 
@@ -417,7 +418,7 @@ class MartingaleStrategy(StrategyBase):
                     stake *= coeff
                 elif profit > 0:
                     log(
-                        f"[{self.symbol}] ✅ WIN: profit={profit:.2f}. Серия завершена, откат к базе."
+                        f"[{self.symbol}] ✅ WIN: profit={format_amount(profit)}. Серия завершена, откат к базе."
                     )
                     break
                 elif abs(profit) < 1e-9:
@@ -426,7 +427,7 @@ class MartingaleStrategy(StrategyBase):
                     )
                 else:
                     log(
-                        f"[{self.symbol}] ❌ LOSS: profit={profit:.2f}. Увеличиваем ставку."
+                        f"[{self.symbol}] ❌ LOSS: profit={format_amount(profit)}. Увеличиваем ставку."
                     )
                     step += 1
                     stake *= coeff

--- a/strategies/oscar_grind_1.py
+++ b/strategies/oscar_grind_1.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from strategies.oscar_grind_2 import OscarGrind2Strategy
+from core.money import format_amount
 
 
 class OscarGrind1Strategy(OscarGrind2Strategy):
@@ -28,21 +29,21 @@ class OscarGrind1Strategy(OscarGrind2Strategy):
         if outcome == "win":
             next_stake = stake + base_unit
             log(
-                f"[{self.symbol}] ✅ WIN: profit={profit:.2f}. "
-                f"Накоплено {cum_profit:.2f}/{target_profit:.2f}. "
-                f"Следующая ставка = stake+unit → {next_stake:.2f}"
+                f"[{self.symbol}] ✅ WIN: profit={format_amount(profit)}. "
+                f"Накоплено {format_amount(cum_profit)}/{format_amount(target_profit)}. "
+                f"Следующая ставка = stake+unit → {format_amount(next_stake)}"
             )
         else:
             next_stake = stake
             if outcome == "refund":
                 log(
                     f"[{self.symbol}] ↩️ REFUND: ставка возвращена. "
-                    f"Следующая ставка остаётся {next_stake:.2f}."
+                    f"Следующая ставка остаётся {format_amount(next_stake)}."
                 )
             else:
                 log(
-                    f"[{self.symbol}] ❌ LOSS: profit={profit:.2f}. "
-                    f"Следующая ставка остаётся {next_stake:.2f}."
+                    f"[{self.symbol}] ❌ LOSS: profit={format_amount(profit)}. "
+                    f"Следующая ставка остаётся {format_amount(next_stake)}."
                 )
         return float(next_stake)
 

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -16,6 +16,7 @@ from core.intrade_api_async import (
 from core.signal_waiter import wait_for_signal_versioned, peek_signal_state
 from strategies.base import StrategyBase
 from core.policy import normalize_sprint
+from core.money import format_amount
 
 # Берём вспомогательные вещи из мартингейла, чтобы не дублировать
 from strategies.martingale import (
@@ -159,7 +160,7 @@ class OscarGrind2Strategy(StrategyBase):
                 self.http_client, self.user_id, self.user_hash
             )
             log(
-                f"[{self.symbol}] Баланс: {display} ({amount:.2f}), текущая валюта: {cur_ccy}, якорь: {self._anchor_ccy}"
+                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}, якорь: {self._anchor_ccy}"
             )
         except Exception as e:
             log(f"[{self.symbol}] ⚠ Не удалось получить баланс при старте: {e}")
@@ -212,7 +213,7 @@ class OscarGrind2Strategy(StrategyBase):
             min_balance = float(self.params.get("min_balance", DEFAULTS["min_balance"]))
             if bal < min_balance:
                 log(
-                    f"[{self.symbol}] ⛔ Баланс ниже минимума ({bal:.2f} < {min_balance:.2f}). Ожидание..."
+                    f"[{self.symbol}] ⛔ Баланс ниже минимума ({format_amount(bal)} < {format_amount(min_balance)}). Ожидание..."
                 )
                 await self.sleep(2.0)
                 continue
@@ -325,12 +326,12 @@ class OscarGrind2Strategy(StrategyBase):
                 )
                 if cur_balance is None or (cur_balance - stake) < min_floor:
                     log(
-                        f"[{self.symbol}] 🛑 Сделка {stake:.2f} {account_ccy} может опустить баланс ниже "
-                        f"{min_floor:.2f} {account_ccy}"
+                        f"[{self.symbol}] 🛑 Сделка {format_amount(stake)} {account_ccy} может опустить баланс ниже "
+                        f"{format_amount(min_floor)} {account_ccy}"
                         + (
                             ""
                             if cur_balance is None
-                            else f" (текущий {cur_balance:.2f} {account_ccy})"
+                            else f" (текущий {format_amount(cur_balance)} {account_ccy})"
                         )
                         + ". Останавливаю стратегию."
                     )
@@ -345,7 +346,7 @@ class OscarGrind2Strategy(StrategyBase):
                 account_mode = "ДЕМО" if demo_now else "РЕАЛ"
 
                 log(
-                    f"[{self.symbol}] step={step_idx + 1} stake={stake:.2f} min={self._trade_minutes} "
+                    f"[{self.symbol}] step={step_idx + 1} stake={format_amount(stake)} min={self._trade_minutes} "
                     f"side={'UP' if status == 1 else 'DOWN'} payout={pct}%"
                 )
 
@@ -439,8 +440,8 @@ class OscarGrind2Strategy(StrategyBase):
                 # Проверим цель
                 if cum_profit >= target_profit:
                     log(
-                        f"[{self.symbol}] ✅ Серия завершена: достигнута цель {target_profit:.2f} "
-                        f"(накоплено {cum_profit:.2f})."
+                        f"[{self.symbol}] ✅ Серия завершена: достигнута цель {format_amount(target_profit)} "
+                        f"(накоплено {format_amount(cum_profit)})."
                     )
                     step_idx += 1
                     break
@@ -501,21 +502,21 @@ class OscarGrind2Strategy(StrategyBase):
             next_req = math.ceil(need / k) if k > 0 else stake
             next_stake = max(base_unit, min(stake + base_unit, float(next_req)))
             log(
-                f"[{self.symbol}] ✅ WIN: profit={profit:.2f}. "
-                f"Накоплено {cum_profit:.2f}/{target_profit:.2f}. "
-                f"Следующая ставка = min(stake+unit, req) → {stake + base_unit:.2f} / {next_req:.2f} = {next_stake:.2f}"
+                f"[{self.symbol}] ✅ WIN: profit={format_amount(profit)}. "
+                f"Накоплено {format_amount(cum_profit)}/{format_amount(target_profit)}. "
+                f"Следующая ставка = min(stake+unit, req) → {format_amount(stake + base_unit)} / {format_amount(next_req)} = {format_amount(next_stake)}"
             )
         else:
             next_stake = stake
             if outcome == "refund":
                 log(
                     f"[{self.symbol}] ↩️ REFUND: ставка возвращена. "
-                    f"Следующая ставка остаётся {next_stake:.2f}."
+                    f"Следующая ставка остаётся {format_amount(next_stake)}."
                 )
             else:
                 log(
-                    f"[{self.symbol}] ❌ LOSS: profit={profit:.2f}. "
-                    f"Следующая ставка остаётся {next_stake:.2f}."
+                    f"[{self.symbol}] ❌ LOSS: profit={format_amount(profit)}. "
+                    f"Следующая ставка остаётся {format_amount(next_stake)}."
                 )
         return float(next_stake)
 


### PR DESCRIPTION
## Summary
- Make all GUI tables use stretching headers so columns share space evenly
- Ensure main window and dialogs resize to fit their contents
- Switch money formatting to use comma as decimal separator and suppress logging of "none" signals

## Testing
- `python -m py_compile core/money.py gui/trades_table_widget.py gui/main_window.py gui/bot_add_dialog.py gui/risk_dialog.py gui/strategy_control_dialog.py core/intrade_api.py core/intrade_api_async.py core/ws_client.py strategies/martingale.py strategies/oscar_grind_2.py strategies/oscar_grind_1.py`


------
https://chatgpt.com/codex/tasks/task_e_68af31ffff5483228c1b082dea75b74c