### PR TITLE
Антимартин: ожидание сигнала на каждом шаге и max_steps=3

### DIFF
--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -174,7 +174,8 @@ class StrategyControlDialog(QDialog):
             self.base_investment.setValue(int(getv("base_investment", 100)))
             self.max_steps = QSpinBox()
             self.max_steps.setRange(1, 20)
-            self.max_steps.setValue(int(getv("max_steps", 5)))
+            default_max_steps = 3 if strategy_key == "antimartin" else 5
+            self.max_steps.setValue(int(getv("max_steps", default_max_steps)))
             self.repeat_count = QSpinBox()
             self.repeat_count.setRange(1, 1000)
             self.repeat_count.setValue(int(getv("repeat_count", 10)))

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -239,7 +239,6 @@ class AntiMartingaleStrategy(StrategyBase):
 
             step = 0
             did_place_any_trade = False
-            series_direction = None
 
             while self._running and step < max_steps:
                 await self._pause_point()
@@ -249,21 +248,18 @@ class AntiMartingaleStrategy(StrategyBase):
                 if not await self._ensure_anchor_account_mode():
                     continue
 
-                if series_direction is None:
-                    self._status("ожидание сигнала")
+                self._status("ожидание сигнала")
+                log(
+                    f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe} (шаг {step})..."
+                )
+                try:
+                    direction = await self.wait_signal(timeout=sig_timeout)
+                except asyncio.TimeoutError:
                     log(
-                        f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe} (шаг {step})..."
+                        f"[{self.symbol}] ⌛ Таймаут ожидания сигнала внутри серии — выхожу из серии."
                     )
-                    try:
-                        direction = await self.wait_signal(timeout=sig_timeout)
-                    except asyncio.TimeoutError:
-                        log(
-                            f"[{self.symbol}] ⌛ Таймаут ожидания сигнала внутри серии — выхожу из серии."
-                        )
-                        break
-                    series_direction = 1 if int(direction) == 1 else 2
-
-                status = series_direction
+                    break
+                status = 1 if int(direction) == 1 else 2
 
                 pct = await get_current_percent(
                     self.http_client,


### PR DESCRIPTION
## Summary
- Antimartin no longer fixes trade direction and waits for a signal before every step
- Default maximum steps set to 3 for Antimartin in control dialog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afc538561c8322bfd6c06763aff8a4