### PR TITLE
Allow AntiMartingale series to use any pair and timeframe

### DIFF
--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -242,6 +242,12 @@ class AntiMartingaleStrategy(StrategyBase):
 
             while self._running and step < max_steps:
                 await self._pause_point()
+                # В отличие от мартингейла не фиксируемся на паре/таймфрейме
+                if self._use_any_symbol:
+                    self.symbol = "*"
+                if self._use_any_timeframe:
+                    self.timeframe = "*"
+                    self.params["timeframe"] = self.timeframe
 
                 if not await self._ensure_anchor_currency():
                     continue


### PR DESCRIPTION
## Summary
- Reset AntiMartingale symbol and timeframe before each step so series can follow signals from any pair or timeframe

## Testing
- `python -m py_compile strategies/antimartin.py`
- `pytest >/tmp/pytest.log 2>&1; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68afc87d74e483229b2b390169330e13