### PR TITLE
Use cross symbol for bot deletion

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -439,7 +439,7 @@ class MainWindow(QWidget):
             btn_pause = QPushButton("⏸", self)
             btn_pause.setEnabled(False)
             btn_pause.clicked.connect(partial(self._toggle_pause_clicked, bot))
-            btn_del = QPushButton("🗑", self)
+            btn_del = QPushButton("×", self)
             btn_del.clicked.connect(partial(self.delete_bot, bot))
             hl.addWidget(btn_pause)
             hl.addWidget(btn_del)
@@ -528,7 +528,7 @@ class MainWindow(QWidget):
         key = bot.strategy_kwargs.get("strategy_key", "")
         sym = bot.strategy_kwargs.get("symbol")
         label = self.strategy_label(key)
-        self.append_to_log(f"🗑 Удалён бот: {label} [{sym}]")
+        self.append_to_log(f"× Удалён бот: {label} [{sym}]")
 
     def open_settings_dialog(self, bot):
         from gui.settings_factory import get_settings_dialog_cls

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -211,7 +211,7 @@ class StrategyControlDialog(QDialog):
         ch = QHBoxLayout(controls)
         self.btn_toggle = QPushButton("🚀 Старт")
         self.btn_stop = QPushButton("⏹ Стоп")
-        self.btn_delete = QPushButton("🗑 Удалить")
+        self.btn_delete = QPushButton("× Удалить")
 
         self.btn_toggle.clicked.connect(self._do_toggle)
         self.btn_stop.clicked.connect(self._do_stop)


### PR DESCRIPTION
## Summary
- replace trash icon with a cross for removing bots
- update bot deletion log message

## Testing
- `python -m py_compile gui/main_window.py gui/strategy_control_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_68afd9da3b688322a5cf3a7c4cf4d6d1