### PR TITLE
Add Fibonacci trading strategy

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -45,6 +45,7 @@ from strategies.martingale import MartingaleStrategy
 from strategies.oscar_grind_1 import OscarGrind1Strategy
 from strategies.oscar_grind_2 import OscarGrind2Strategy
 from strategies.antimartin import AntiMartingaleStrategy
+from strategies.fibonacci import FibonacciStrategy
 
 
 class MainWindow(QWidget):
@@ -97,12 +98,14 @@ class MainWindow(QWidget):
             "antimartin": AntiMartingaleStrategy,
             "oscar_grind_1": OscarGrind1Strategy,
             "oscar_grind_2": OscarGrind2Strategy,
+            "fibonacci": FibonacciStrategy,
         }
         self.strategy_labels = {
             "martingale": "Мартингейл",
             "antimartin": "Антимартин",
             "oscar_grind_1": "Оскар Грайнд 1",
             "oscar_grind_2": "Оскар Грайнд 2",
+            "fibonacci": "Фибоначчи",
         }
 
         self.bot_ever_started = defaultdict(bool)

--- a/gui/settings_factory.py
+++ b/gui/settings_factory.py
@@ -4,15 +4,18 @@ from strategies.martingale import MartingaleStrategy
 from strategies.oscar_grind_1 import OscarGrind1Strategy
 from strategies.oscar_grind_2 import OscarGrind2Strategy
 from strategies.antimartin import AntiMartingaleStrategy
+from strategies.fibonacci import FibonacciStrategy
 from gui.settings_martingale import MartingaleSettingsDialog
 from gui.settings_oscar_grind import OscarGrindSettingsDialog
 from gui.settings_antimartin import AntimartinSettingsDialog
+from gui.settings_fibonacci import FibonacciSettingsDialog
 
 _registry: Dict[Type, Type[QDialog]] = {
     MartingaleStrategy: MartingaleSettingsDialog,
     OscarGrind1Strategy: OscarGrindSettingsDialog,
     OscarGrind2Strategy: OscarGrindSettingsDialog,
     AntiMartingaleStrategy: AntimartinSettingsDialog,
+    FibonacciStrategy: FibonacciSettingsDialog,
 }
 
 

--- a/gui/settings_fibonacci.py
+++ b/gui/settings_fibonacci.py
@@ -1,0 +1,75 @@
+from PyQt6.QtWidgets import (
+    QDialog,
+    QFormLayout,
+    QSpinBox,
+    QDialogButtonBox,
+)
+from strategies.martingale import _minutes_from_timeframe
+from core.policy import normalize_sprint
+
+
+class FibonacciSettingsDialog(QDialog):
+    def __init__(self, params: dict, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Настройки: Fibonacci")
+        self.params = params.copy()
+
+        tf = str(self.params.get("timeframe", "M1"))
+        symbol = str(self.params.get("symbol", ""))
+        default_minutes = int(self.params.get("minutes", _minutes_from_timeframe(tf)))
+
+        self.minutes = QSpinBox()
+        self.minutes.setRange(5 if symbol == "BTCUSDT" else 1, 500)
+        self.minutes.setValue(default_minutes)
+
+        self.base_investment = QSpinBox()
+        self.base_investment.setRange(1, 50000)
+        self.base_investment.setValue(self.params.get("base_investment", 100))
+
+        self.max_steps = QSpinBox()
+        self.max_steps.setRange(1, 20)
+        self.max_steps.setValue(self.params.get("max_steps", 5))
+
+        self.repeat_count = QSpinBox()
+        self.repeat_count.setRange(1, 1000)
+        self.repeat_count.setValue(self.params.get("repeat_count", 10))
+
+        self.min_balance = QSpinBox()
+        self.min_balance.setRange(1, 10_000_000)
+        self.min_balance.setValue(self.params.get("min_balance", 100))
+
+        self.min_percent = QSpinBox()
+        self.min_percent.setRange(0, 100)
+        self.min_percent.setValue(self.params.get("min_percent", 70))
+
+        form = QFormLayout()
+        form.addRow("Базовая ставка", self.base_investment)
+        form.addRow("Время экспирации (мин)", self.minutes)
+        form.addRow("Макс. шагов", self.max_steps)
+        form.addRow("Повторов серии", self.repeat_count)
+        form.addRow("Мин. баланс", self.min_balance)
+        form.addRow("Мин. процент", self.min_percent)
+
+        btns = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        btns.accepted.connect(self.accept)
+        btns.rejected.connect(self.reject)
+
+        form.addRow(btns)
+        self.setLayout(form)
+
+    def get_params(self) -> dict:
+        symbol = str(self.params.get("symbol", ""))
+        m = int(self.minutes.value())
+        norm = normalize_sprint(symbol, m)
+        if norm is None:
+            norm = 5 if symbol == "BTCUSDT" else (1 if m < 3 else max(3, min(500, m)))
+        return {
+            "minutes": int(norm),
+            "base_investment": self.base_investment.value(),
+            "max_steps": self.max_steps.value(),
+            "repeat_count": self.repeat_count.value(),
+            "min_balance": self.min_balance.value(),
+            "min_percent": self.min_percent.value(),
+        }

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -1,0 +1,382 @@
+# strategies/fibonacci.py
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from strategies.martingale import MartingaleStrategy, DEFAULTS as MG_DEFAULTS
+from core.http_async import HttpClient
+from core.intrade_api_async import (
+    get_balance_info,
+    get_current_percent,
+    place_trade,
+    check_trade_result,
+    is_demo_account,
+)
+from core.money import format_amount
+
+# Переиспользуем функции ожидания сигнала и прочие методы из MartingaleStrategy
+# через наследование. Здесь определяем собственные значения по умолчанию
+# без коэффициента умножения.
+DEFAULTS = dict(MG_DEFAULTS)
+DEFAULTS.pop("coefficient", None)
+
+
+def _fib(n: int) -> int:
+    """Возвращает n-е число Фибоначчи (1-indexed)."""
+    seq = [1, 1]
+    while len(seq) < n:
+        seq.append(seq[-1] + seq[-2])
+    return seq[n - 1]
+
+
+class FibonacciStrategy(MartingaleStrategy):
+    """Стратегия по последовательности Фибоначчи.
+
+    При каждом поражении ставка увеличивается по ряду Фибоначчи.
+    При победе откат происходит на два шага назад.
+    Перед каждой ставкой стратегия ожидает сигнал.
+    """
+
+    def __init__(
+        self,
+        http_client: HttpClient,
+        user_id: str,
+        user_hash: str,
+        symbol: str,
+        log_callback=None,
+        *,
+        timeframe: str = "M1",
+        params: Optional[dict] = None,
+        **_,
+    ):
+        # объединяем параметры с локальными значениями по умолчанию
+        p = dict(DEFAULTS)
+        if params:
+            p.update(params)
+        super().__init__(
+            http_client,
+            user_id,
+            user_hash,
+            symbol,
+            log_callback,
+            timeframe=timeframe,
+            params=p,
+        )
+        # параметр coefficient не используется в этой стратегии
+        self.params.pop("coefficient", None)
+
+    async def run(self) -> None:  # noqa: C901 - сложность как у базовых стратегий
+        self._running = True
+        log = self.log or (lambda s: None)
+
+        try:
+            self._anchor_is_demo = await is_demo_account(self.http_client)
+            mode_txt = "ДЕМО" if self._anchor_is_demo else "РЕАЛ"
+            log(f"[{self.symbol}] Якорный режим счёта: {mode_txt}")
+        except Exception as e:  # pragma: no cover - сеть
+            log(f"[{self.symbol}] ⚠ Не удалось определить режим счёта при старте: {e}")
+            self._anchor_is_demo = False
+
+        try:
+            amount, cur_ccy, display = await get_balance_info(
+                self.http_client, self.user_id, self.user_hash
+            )
+            log(
+                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}, якорь: {self._anchor_ccy}"
+            )
+        except Exception as e:  # pragma: no cover - сеть
+            log(f"[{self.symbol}] ⚠ Не удалось получить баланс при старте: {e}")
+
+        series_left = int(self.params.get("repeat_count", DEFAULTS["repeat_count"]))
+        if series_left <= 0:
+            log(
+                f"[{self.symbol}] 🛑 repeat_count={series_left} — нечего выполнять. Завершение."
+            )
+            self._running = False
+            (self.log or (lambda s: None))(f"[{self.symbol}] Завершение стратегии.")
+            return
+
+        try:
+            if self.symbol != "*" and self.timeframe != "*":
+                from core.signal_waiter import peek_signal_state
+
+                st = peek_signal_state(self.symbol, self.timeframe)
+                self._last_signal_ver = st.get("version", 0) or 0
+                if self.log:
+                    self.log(
+                        f"[{self.symbol}] Заякорена версия сигнала: v{self._last_signal_ver}"
+                    )
+            else:
+                self._last_signal_ver = 0
+        except Exception:  # pragma: no cover
+            self._last_signal_ver = 0
+
+        next_start_step = 1
+        while self._running and series_left > 0:
+            self._last_signal_at_str = None
+            await self._pause_point()
+
+            if self._use_any_symbol:
+                self.symbol = "*"
+            if self._use_any_timeframe:
+                self.timeframe = "*"
+                self.params["timeframe"] = self.timeframe
+
+            if not await self._ensure_anchor_currency():
+                continue
+            if not await self._ensure_anchor_account_mode():
+                continue
+
+            try:
+                bal, _, _ = await get_balance_info(
+                    self.http_client, self.user_id, self.user_hash
+                )
+            except Exception:  # pragma: no cover
+                bal = 0.0
+
+            min_balance = float(
+                self.params.get("min_balance", DEFAULTS["min_balance"])
+            )
+            if bal < min_balance:
+                log(
+                    f"[{self.symbol}] ⛔ Баланс ниже минимума ({format_amount(bal)} < {format_amount(min_balance)}). Ожидание..."
+                )
+                await self.sleep(2.0)
+                continue
+
+            base = float(
+                self.params.get("base_investment", DEFAULTS["base_investment"])
+            )
+            max_steps = int(
+                self.params.get("max_steps", DEFAULTS["max_steps"])
+            )
+            min_pct = int(self.params.get("min_percent", DEFAULTS["min_percent"]))
+            wait_low = float(
+                self.params.get(
+                    "wait_on_low_percent", DEFAULTS["wait_on_low_percent"]
+                )
+            )
+            result_wait_s = float(
+                self.params.get("result_wait_s", DEFAULTS["result_wait_s"])
+            )
+            sig_timeout = float(
+                self.params.get("signal_timeout_sec", DEFAULTS["signal_timeout_sec"])
+            )
+            account_ccy = self._anchor_ccy
+
+            if max_steps <= 0:
+                log(
+                    f"[{self.symbol}] ⚠ max_steps={max_steps} — серию не стартуем. Жду следующий сигнал."
+                )
+                await self.sleep(1.0)
+                continue
+
+            step = next_start_step
+            did_place_any_trade = False
+            series_direction = None
+
+            while self._running and step <= max_steps:
+                await self._pause_point()
+
+                if not await self._ensure_anchor_currency():
+                    continue
+                if not await self._ensure_anchor_account_mode():
+                    continue
+
+                stake = base * _fib(step)
+
+                pct = await get_current_percent(
+                    self.http_client,
+                    investment=stake,
+                    option=self.symbol,
+                    minutes=self._trade_minutes,
+                    account_ccy=account_ccy,
+                )
+                if pct is None:
+                    self._status("ожидание процента")
+                    log(f"[{self.symbol}] ⚠ Не получили % выплаты. Пауза и повтор.")
+                    await self.sleep(1.0)
+                    continue
+                if pct < min_pct:
+                    self._status("ожидание высокого процента")
+                    if not self._low_payout_notified:
+                        log(
+                            f"[{self.symbol}] ℹ Низкий payout {pct}% < {min_pct}% — ждём..."
+                        )
+                        self._low_payout_notified = True
+                    await self.sleep(wait_low)
+                    continue
+                if self._low_payout_notified:
+                    log(
+                        f"[{self.symbol}] ℹ Работа продолжается (текущий payout = {pct}%)"
+                    )
+                    self._low_payout_notified = False
+
+                if series_direction is None:
+                    self._status("ожидание сигнала")
+                    log(
+                        f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe} (шаг {step})..."
+                    )
+                    try:
+                        direction = await self.wait_signal(timeout=sig_timeout)
+                    except asyncio.TimeoutError:
+                        log(
+                            f"[{self.symbol}] ⌛ Таймаут ожидания сигнала внутри серии — выхожу из серии."
+                        )
+                        break
+                    series_direction = 1 if int(direction) == 1 else 2
+
+                status = series_direction
+
+                try:
+                    cur_balance, _, _ = await get_balance_info(
+                        self.http_client, self.user_id, self.user_hash
+                    )
+                except Exception:  # pragma: no cover
+                    cur_balance = None
+                min_floor = float(
+                    self.params.get("min_balance", DEFAULTS["min_balance"])
+                )
+                if cur_balance is None or (cur_balance - stake) < min_floor:
+                    log(
+                        f"[{self.symbol}] 🛑 Сделка {format_amount(stake)} {account_ccy} может опустить баланс ниже "
+                        f"{format_amount(min_floor)} {account_ccy}"
+                        + (
+                            ""
+                            if cur_balance is None
+                            else f" (текущий {format_amount(cur_balance)} {account_ccy})"
+                        )
+                        + ". Останавливаю стратегию."
+                    )
+                    self._running = False
+                    break
+
+                if not await self._ensure_anchor_currency():
+                    continue
+                if not await self._ensure_anchor_account_mode():
+                    continue
+
+                log(
+                    f"[{self.symbol}] step={step} stake={format_amount(stake)} min={self._trade_minutes} "
+                    f"side={'UP' if status == 1 else 'DOWN'} payout={pct}%"
+                )
+
+                try:
+                    demo_now = await is_demo_account(self.http_client)
+                except Exception:
+                    demo_now = False
+                account_mode = "ДЕМО" if demo_now else "РЕАЛ"
+
+                self._status("делает ставку")
+                trade_id = await place_trade(
+                    self.http_client,
+                    user_id=self.user_id,
+                    user_hash=self.user_hash,
+                    investment=stake,
+                    option=self.symbol,
+                    status=status,
+                    minutes=self._trade_minutes,
+                    account_ccy=account_ccy,
+                    strict=True,
+                    on_log=log,
+                )
+                if not trade_id:
+                    log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
+                    await self.sleep(1.0)
+                    continue
+
+                did_place_any_trade = True
+
+                if callable(self._on_trade_pending):
+                    from datetime import datetime
+
+                    placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+                    try:
+                        self._on_trade_pending(
+                            trade_id=trade_id,
+                            symbol=self.symbol,
+                            timeframe=self.timeframe,
+                            signal_at=self._last_signal_at_str,
+                            placed_at=placed_at_str,
+                            direction=status,
+                            stake=float(stake),
+                            percent=int(pct),
+                            wait_seconds=float(result_wait_s),
+                            account_mode=account_mode,
+                            indicator=self._last_indicator,
+                        )
+                    except Exception:
+                        pass
+
+                self._status("ожидание результата")
+
+                profit = await check_trade_result(
+                    self.http_client,
+                    user_id=self.user_id,
+                    user_hash=self.user_hash,
+                    trade_id=trade_id,
+                    wait_time=result_wait_s,
+                )
+
+                if callable(self._on_trade_result):
+                    from datetime import datetime
+
+                    placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%М:%S")
+                    try:
+                        self._on_trade_result(
+                            trade_id=trade_id,
+                            symbol=self.symbol,
+                            timeframe=self.timeframe,
+                            signal_at=self._last_signal_at_str,
+                            placed_at=placed_at_str,
+                            direction=status,
+                            stake=float(stake),
+                            percent=int(pct),
+                            profit=(None if profit is None else float(profit)),
+                            account_mode=account_mode,
+                            indicator=self._last_indicator,
+                        )
+                    except Exception:
+                        pass
+
+                if profit is None:
+                    log(f"[{self.symbol}] ⚠ Результат неизвестен — считаем как LOSS.")
+                    step += 1
+                elif profit > 0:
+                    log(
+                        f"[{self.symbol}] ✅ WIN: profit={format_amount(profit)}. Откат на два шага назад."
+                    )
+                    next_start_step = max(1, step - 2)
+                    break
+                elif abs(profit) < 1e-9:
+                    log(
+                        f"[{self.symbol}] 🤝 PUSH: возврат ставки. Повтор шага без изменения."
+                    )
+                else:
+                    log(
+                        f"[{self.symbol}] ❌ LOSS: profit={format_amount(profit)}. Переход к следующему числу."
+                    )
+                    step += 1
+
+                await self.sleep(0.2)
+
+            if not self._running:
+                break
+
+            if not did_place_any_trade:
+                log(
+                    f"[{self.symbol}] ℹ Серия завершена без сделок (max_steps={max_steps} или условия не выполнились). "
+                    f"Серий осталось: {series_left}."
+                )
+            else:
+                if step > max_steps:
+                    log(
+                        f"[{self.symbol}] 🛑 Достигнут лимит шагов ({max_steps}). Переход к новой серии."
+                    )
+                    next_start_step = 1
+                series_left -= 1
+                log(f"[{self.symbol}] ▶ Осталось серий: {series_left}")
+
+        self._running = False
+        (self.log or (lambda s: None))(f"[{self.symbol}] Завершение стратегии.")


### PR DESCRIPTION
## Summary
- add FibonacciStrategy implementing Fibonacci-based stake progression
- provide GUI dialog for configuring Fibonacci strategy
- register Fibonacci strategy in GUI factory and main window

## Testing
- `python -m py_compile intradevor/strategies/fibonacci.py intradevor/gui/settings_fibonacci.py intradevor/gui/settings_factory.py intradevor/gui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68afe16fb1088322afe90a98c422464b