### PR TITLE
Add Fixed Stake strategy with settings UI

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -46,6 +46,7 @@ from strategies.oscar_grind_1 import OscarGrind1Strategy
 from strategies.oscar_grind_2 import OscarGrind2Strategy
 from strategies.antimartin import AntiMartingaleStrategy
 from strategies.fibonacci import FibonacciStrategy
+from strategies.fixed import FixedStakeStrategy
 
 
 class MainWindow(QWidget):
@@ -99,6 +100,7 @@ class MainWindow(QWidget):
             "oscar_grind_1": OscarGrind1Strategy,
             "oscar_grind_2": OscarGrind2Strategy,
             "fibonacci": FibonacciStrategy,
+            "fixed": FixedStakeStrategy,
         }
         self.strategy_labels = {
             "martingale": "Мартингейл",
@@ -106,6 +108,7 @@ class MainWindow(QWidget):
             "oscar_grind_1": "Оскар Грайнд 1",
             "oscar_grind_2": "Оскар Грайнд 2",
             "fibonacci": "Фибоначчи",
+            "fixed": "Фиксированная ставка",
         }
 
         self.bot_ever_started = defaultdict(bool)

--- a/gui/settings_factory.py
+++ b/gui/settings_factory.py
@@ -5,10 +5,12 @@ from strategies.oscar_grind_1 import OscarGrind1Strategy
 from strategies.oscar_grind_2 import OscarGrind2Strategy
 from strategies.antimartin import AntiMartingaleStrategy
 from strategies.fibonacci import FibonacciStrategy
+from strategies.fixed import FixedStakeStrategy
 from gui.settings_martingale import MartingaleSettingsDialog
 from gui.settings_oscar_grind import OscarGrindSettingsDialog
 from gui.settings_antimartin import AntimartinSettingsDialog
 from gui.settings_fibonacci import FibonacciSettingsDialog
+from gui.settings_fixed import FixedSettingsDialog
 
 _registry: Dict[Type, Type[QDialog]] = {
     MartingaleStrategy: MartingaleSettingsDialog,
@@ -16,6 +18,7 @@ _registry: Dict[Type, Type[QDialog]] = {
     OscarGrind2Strategy: OscarGrindSettingsDialog,
     AntiMartingaleStrategy: AntimartinSettingsDialog,
     FibonacciStrategy: FibonacciSettingsDialog,
+    FixedStakeStrategy: FixedSettingsDialog,
 }
 
 

--- a/gui/settings_fixed.py
+++ b/gui/settings_fixed.py
@@ -1,0 +1,70 @@
+from PyQt6.QtWidgets import (
+    QDialog,
+    QFormLayout,
+    QSpinBox,
+    QDialogButtonBox,
+)
+from strategies.martingale import _minutes_from_timeframe
+from core.policy import normalize_sprint
+
+
+class FixedSettingsDialog(QDialog):
+    def __init__(self, params: dict, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Настройки: Фиксированная ставка")
+        self.params = params.copy()
+
+        tf = str(self.params.get("timeframe", "M1"))
+        symbol = str(self.params.get("symbol", ""))
+        default_minutes = int(self.params.get("minutes", _minutes_from_timeframe(tf)))
+
+        self.minutes = QSpinBox()
+        self.minutes.setRange(5 if symbol == "BTCUSDT" else 1, 500)
+        self.minutes.setValue(default_minutes)
+
+        self.base_investment = QSpinBox()
+        self.base_investment.setRange(1, 50000)
+        self.base_investment.setValue(self.params.get("base_investment", 100))
+
+        self.repeat_count = QSpinBox()
+        self.repeat_count.setRange(1, 1000)
+        self.repeat_count.setValue(self.params.get("repeat_count", 10))
+
+        self.min_balance = QSpinBox()
+        self.min_balance.setRange(1, 10_000_000)
+        self.min_balance.setValue(self.params.get("min_balance", 100))
+
+        self.min_percent = QSpinBox()
+        self.min_percent.setRange(0, 100)
+        self.min_percent.setValue(self.params.get("min_percent", 70))
+
+        form = QFormLayout()
+        form.addRow("Базовая ставка", self.base_investment)
+        form.addRow("Время экспирации (мин)", self.minutes)
+        form.addRow("Количество ставок", self.repeat_count)
+        form.addRow("Мин. баланс", self.min_balance)
+        form.addRow("Мин. процент", self.min_percent)
+
+        btns = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        btns.accepted.connect(self.accept)
+        btns.rejected.connect(self.reject)
+
+        form.addRow(btns)
+        self.setLayout(form)
+
+    def get_params(self) -> dict:
+        symbol = str(self.params.get("symbol", ""))
+        m = int(self.minutes.value())
+        norm = normalize_sprint(symbol, m)
+        if norm is None:
+            norm = 5 if symbol == "BTCUSDT" else (1 if m < 3 else max(3, min(500, m)))
+        return {
+            "minutes": int(norm),
+            "base_investment": self.base_investment.value(),
+            "repeat_count": self.repeat_count.value(),
+            "min_balance": self.min_balance.value(),
+            "min_percent": self.min_percent.value(),
+        }
+

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -163,6 +163,33 @@ class StrategyControlDialog(QDialog):
             form.addRow("Мин. баланс", self.min_balance)
             form.addRow("Мин. процент", self.min_percent)
             form.addRow("Фиксировать направление (0/1)", self.lock_direction)
+        elif strategy_key == "fixed":
+            self.minutes = QSpinBox()
+            self.minutes.setRange(5 if symbol == "BTCUSDT" else 1, 500)
+            self.minutes.setValue(default_minutes)
+            self.minutes.setToolTip("1; 3-500 мин; BTCUSDT: 5-500 мин")
+
+            self.base_investment = QSpinBox()
+            self.base_investment.setRange(1, 50_000)
+            self.base_investment.setValue(int(getv("base_investment", 100)))
+
+            self.repeat_count = QSpinBox()
+            self.repeat_count.setRange(1, 1000)
+            self.repeat_count.setValue(int(getv("repeat_count", 10)))
+
+            self.min_balance = QSpinBox()
+            self.min_balance.setRange(1, 10_000_000)
+            self.min_balance.setValue(int(getv("min_balance", 100)))
+
+            self.min_percent = QSpinBox()
+            self.min_percent.setRange(0, 100)
+            self.min_percent.setValue(int(getv("min_percent", 70)))
+
+            form.addRow("Базовая ставка", self.base_investment)
+            form.addRow("Время сделки (мин)", self.minutes)
+            form.addRow("Количество ставок", self.repeat_count)
+            form.addRow("Мин. баланс", self.min_balance)
+            form.addRow("Мин. процент", self.min_percent)
         else:
             self.minutes = QSpinBox()
             self.minutes.setRange(5 if symbol == "BTCUSDT" else 1, 500)
@@ -367,6 +394,14 @@ class StrategyControlDialog(QDialog):
                 "min_balance": self.min_balance.value(),
                 "min_percent": self.min_percent.value(),
                 "lock_direction_to_first": bool(self.lock_direction.value() == 1),
+                "minutes": int(norm),
+            }
+        elif getattr(self, "strategy_key", "") == "fixed":
+            new_params = {
+                "base_investment": self.base_investment.value(),
+                "repeat_count": self.repeat_count.value(),
+                "min_balance": self.min_balance.value(),
+                "min_percent": self.min_percent.value(),
                 "minutes": int(norm),
             }
         else:

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -1,0 +1,513 @@
+# strategies/fixed.py
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from core.http_async import HttpClient
+from core.intrade_api_async import (
+    get_balance_info,
+    get_current_percent,
+    place_trade,
+    check_trade_result,
+    is_demo_account,
+)
+from core.signal_waiter import wait_for_signal_versioned, peek_signal_state
+from strategies.base import StrategyBase
+from core.money import format_amount
+from core.policy import normalize_sprint
+
+ALL_SYMBOLS_LABEL = "Все валютные пары"
+ALL_TF_LABEL = "Все таймфреймы"
+
+DEFAULTS = {
+    "base_investment": 100,
+    "repeat_count": 10,
+    "min_balance": 100,
+    "min_percent": 70,
+    "wait_on_low_percent": 1,
+    "signal_timeout_sec": 3600,
+    "account_currency": "RUB",
+    "result_wait_s": 60.0,
+    "grace_delay_sec": 30.0,
+}
+
+
+def _minutes_from_timeframe(tf: str) -> int:
+    if not tf:
+        return 1
+    unit = tf[0].upper()
+    try:
+        n = int(tf[1:])
+    except Exception:
+        return 1
+    if unit == "M":
+        return n
+    if unit == "H":
+        return n * 60
+    if unit == "D":
+        return n * 60 * 24
+    if unit == "W":
+        return n * 60 * 24 * 7
+    return 1
+
+
+class FixedStakeStrategy(StrategyBase):
+    """Простая стратегия: ставит фиксированную ставку на каждый сигнал."""
+
+    def __init__(
+        self,
+        http_client: HttpClient,
+        user_id: str,
+        user_hash: str,
+        symbol: str,
+        log_callback=None,
+        *,
+        timeframe: str = "M1",
+        params: Optional[dict] = None,
+        **_,
+    ):
+        p = dict(DEFAULTS)
+        if params:
+            p.update(params)
+
+        _symbol = (symbol or "").strip()
+        _tf_raw = (timeframe or "").strip()
+        _tf = _tf_raw.upper()
+        self._use_any_symbol = _symbol == ALL_SYMBOLS_LABEL
+        self._use_any_timeframe = _tf_raw == ALL_TF_LABEL
+
+        cur_symbol = "*" if self._use_any_symbol else _symbol
+        cur_tf = "*" if self._use_any_timeframe else _tf
+
+        super().__init__(
+            session=http_client,
+            user_id=user_id,
+            user_hash=user_hash,
+            symbol=cur_symbol,
+            log_callback=log_callback,
+            **p,
+        )
+
+        self.http_client = http_client
+        self.timeframe = cur_tf or self.params.get("timeframe", "M1")
+        self.params["timeframe"] = self.timeframe
+
+        raw_minutes = int(
+            self.params.get("minutes", _minutes_from_timeframe(self.timeframe))
+        )
+        norm = normalize_sprint(cur_symbol, raw_minutes)
+        if norm is None:
+            fallback = _minutes_from_timeframe(self.timeframe)
+            norm = normalize_sprint(cur_symbol, fallback) or fallback
+            if self.log:
+                self.log(
+                    f"[{cur_symbol}] ⚠ Минуты {raw_minutes} недопустимы. Использую {norm}."
+                )
+        self._trade_minutes = int(norm)
+        self.params["minutes"] = self._trade_minutes
+
+        self._on_trade_result = self.params.get("on_trade_result")
+        self._on_trade_pending = self.params.get("on_trade_pending")
+        self._on_status = self.params.get("on_status")
+
+        def _status(msg: str):
+            cb = self._on_status
+            if callable(cb):
+                try:
+                    cb(msg)
+                except Exception:
+                    pass
+
+        self._status = _status
+
+        self._running = False
+        self._last_signal_ver: Optional[int] = None
+        self._last_indicator: str = "-"
+        self._last_signal_at_str: Optional[str] = None
+
+        anchor = str(
+            self.params.get("account_currency", DEFAULTS["account_currency"])
+        ).upper()
+        self._anchor_ccy = anchor
+        self.params["account_currency"] = anchor
+
+        self._anchor_is_demo: Optional[bool] = None
+        self._low_payout_notified = False
+
+    async def run(self) -> None:
+        self._running = True
+        log = self.log or (lambda s: None)
+
+        try:
+            self._anchor_is_demo = await is_demo_account(self.http_client)
+            mode_txt = "ДЕМО" if self._anchor_is_demo else "РЕАЛ"
+            log(f"[{self.symbol}] Якорный режим счёта: {mode_txt}")
+        except Exception as e:
+            log(f"[{self.symbol}] ⚠ Не удалось определить режим счёта при старте: {e}")
+            self._anchor_is_demo = False
+
+        try:
+            amount, cur_ccy, display = await get_balance_info(
+                self.http_client, self.user_id, self.user_hash
+            )
+            log(
+                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}, якорь: {self._anchor_ccy}"
+            )
+        except Exception as e:
+            log(f"[{self.symbol}] ⚠ Не удалось получить баланс при старте: {e}")
+
+        trades_left = int(self.params.get("repeat_count", DEFAULTS["repeat_count"]))
+        if trades_left <= 0:
+            log(
+                f"[{self.symbol}] 🛑 repeat_count={trades_left} — нечего выполнять. Завершение."
+            )
+            self._running = False
+            (self.log or (lambda s: None))(f"[{self.symbol}] Завершение стратегии.")
+            return
+
+        try:
+            if self.symbol != "*" and self.timeframe != "*":
+                st = peek_signal_state(self.symbol, self.timeframe)
+                self._last_signal_ver = st.get("version", 0) or 0
+                if self.log:
+                    self.log(
+                        f"[{self.symbol}] Заякорена версия сигнала: v{self._last_signal_ver}"
+                    )
+            else:
+                self._last_signal_ver = 0
+        except Exception:
+            self._last_signal_ver = 0
+
+        while self._running and trades_left > 0:
+            self._last_signal_at_str = None
+            await self._pause_point()
+
+            if self._use_any_symbol:
+                self.symbol = "*"
+            if self._use_any_timeframe:
+                self.timeframe = "*"
+                self.params["timeframe"] = self.timeframe
+
+            if not await self._ensure_anchor_currency():
+                continue
+            if not await self._ensure_anchor_account_mode():
+                continue
+
+            try:
+                bal, _, _ = await get_balance_info(
+                    self.http_client, self.user_id, self.user_hash
+                )
+            except Exception:
+                bal = 0.0
+
+            min_balance = float(
+                self.params.get("min_balance", DEFAULTS["min_balance"])
+            )
+            if bal < min_balance:
+                log(
+                    f"[{self.symbol}] ⛔ Баланс ниже минимума ({format_amount(bal)} < {format_amount(min_balance)}). Ожидание..."
+                )
+                await self.sleep(2.0)
+                continue
+
+            stake = float(
+                self.params.get("base_investment", DEFAULTS["base_investment"])
+            )
+            min_pct = int(self.params.get("min_percent", DEFAULTS["min_percent"]))
+            wait_low = float(
+                self.params.get("wait_on_low_percent", DEFAULTS["wait_on_low_percent"])
+            )
+            result_wait_s = float(
+                self.params.get("result_wait_s", DEFAULTS["result_wait_s"])
+            )
+            sig_timeout = float(
+                self.params.get("signal_timeout_sec", DEFAULTS["signal_timeout_sec"])
+            )
+            account_ccy = self._anchor_ccy
+
+            try:
+                pct = await get_current_percent(self.http_client, self.symbol)
+            except Exception:
+                pct = 0
+
+            if pct < min_pct:
+                if wait_low > 0:
+                    if not self._low_payout_notified:
+                        log(
+                            f"[{self.symbol}] ℹ Текущий процент {pct}% ниже минимума {min_pct}%. Жду {wait_low}s"
+                        )
+                        self._low_payout_notified = True
+                    await self.sleep(wait_low)
+                    continue
+                else:
+                    log(
+                        f"[{self.symbol}] ⛔ Процент выплаты {pct}% ниже минимума {min_pct}%."
+                    )
+                    await self.sleep(1.0)
+                    continue
+
+            if self._low_payout_notified:
+                log(f"[{self.symbol}] ℹ Работа продолжается (текущий payout = {pct}%)")
+                self._low_payout_notified = False
+
+            self._status("ожидание сигнала")
+            log(
+                f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe}..."
+            )
+
+            try:
+                direction = await self.wait_signal(timeout=sig_timeout)
+            except asyncio.TimeoutError:
+                log(
+                    f"[{self.symbol}] ⌛ Таймаут ожидания сигнала — повтор."
+                )
+                await self.sleep(1.0)
+                continue
+
+            status = 1 if int(direction) == 1 else 2
+
+            try:
+                cur_balance, _, _ = await get_balance_info(
+                    self.http_client, self.user_id, self.user_hash
+                )
+            except Exception:
+                cur_balance = None
+
+            min_floor = float(
+                self.params.get("min_balance", DEFAULTS["min_balance"])
+            )
+            if cur_balance is None or (cur_balance - stake) < min_floor:
+                log(
+                    f"[{self.symbol}] 🛑 Сделка {format_amount(stake)} {account_ccy} может опустить баланс ниже {format_amount(min_floor)}"
+                    + (
+                        ""
+                        if cur_balance is None
+                        else f" (текущий {format_amount(cur_balance)} {account_ccy})"
+                    )
+                    + ". Останавливаю стратегию."
+                )
+                self._running = False
+                break
+
+            if not await self._ensure_anchor_currency():
+                continue
+            if not await self._ensure_anchor_account_mode():
+                continue
+
+            log(
+                f"[{self.symbol}] stake={format_amount(stake)} min={self._trade_minutes} side={'UP' if status == 1 else 'DOWN'} payout={pct}%"
+            )
+
+            try:
+                demo_now = await is_demo_account(self.http_client)
+            except Exception:
+                demo_now = False
+            account_mode = "ДЕМО" if demo_now else "РЕАЛ"
+
+            self._status("делает ставку")
+            trade_id = await place_trade(
+                self.http_client,
+                user_id=self.user_id,
+                user_hash=self.user_hash,
+                investment=stake,
+                option=self.symbol,
+                status=status,
+                minutes=self._trade_minutes,
+                account_ccy=account_ccy,
+                strict=True,
+                on_log=log,
+            )
+            if not trade_id:
+                log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
+                await self.sleep(1.0)
+                continue
+
+            trades_left -= 1
+
+            if callable(self._on_trade_pending):
+                from datetime import datetime
+
+                placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+                try:
+                    self._on_trade_pending(
+                        trade_id=trade_id,
+                        symbol=self.symbol,
+                        timeframe=self.timeframe,
+                        signal_at=self._last_signal_at_str,
+                        placed_at=placed_at_str,
+                        direction=status,
+                        stake=float(stake),
+                        percent=int(pct),
+                        wait_seconds=float(result_wait_s),
+                        account_mode=account_mode,
+                        indicator=self._last_indicator,
+                    )
+                except Exception:
+                    pass
+
+            self._status("ожидание результата")
+
+            profit = await check_trade_result(
+                self.http_client,
+                user_id=self.user_id,
+                user_hash=self.user_hash,
+                trade_id=trade_id,
+                wait_time=result_wait_s,
+            )
+
+            if callable(self._on_trade_result):
+                from datetime import datetime
+
+                placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+                try:
+                    self._on_trade_result(
+                        trade_id=trade_id,
+                        symbol=self.symbol,
+                        timeframe=self.timeframe,
+                        signal_at=self._last_signal_at_str,
+                        placed_at=placed_at_str,
+                        direction=status,
+                        stake=float(stake),
+                        percent=int(pct),
+                        profit=(None if profit is None else float(profit)),
+                        account_mode=account_mode,
+                        indicator=self._last_indicator,
+                    )
+                except Exception:
+                    pass
+
+            if profit is None:
+                log(f"[{self.symbol}] ⚠ Результат неизвестен")
+            elif profit >= 0:
+                log(
+                    f"[{self.symbol}] ✅ Результат: {format_amount(profit)}"
+                )
+            else:
+                log(
+                    f"[{self.symbol}] ❌ Результат: {format_amount(profit)}"
+                )
+
+            await self.sleep(0.2)
+
+        self._running = False
+        (self.log or (lambda s: None))(f"[{self.symbol}] Завершение стратегии.")
+
+    async def wait_signal(self, *, timeout: float) -> int:
+        grace = float(self.params.get("grace_delay_sec", DEFAULTS["grace_delay_sec"]))
+
+        def _on_delay(sec: float):
+            (self.log or (lambda s: None))(
+                f"[{self.symbol}] ⏱ Задержка следующего прогноза ~{sec:.1f}s"
+            )
+
+        coro = wait_for_signal_versioned(
+            self.symbol,
+            self.timeframe,
+            since_version=self._last_signal_ver,
+            check_pause=self.is_paused,
+            timeout=None,
+            raise_on_timeout=True,
+            grace_delay_sec=grace,
+            on_delay=_on_delay,
+            include_meta=True,
+        )
+
+        direction, ver, meta = await self.wait_cancellable(coro, timeout=timeout)
+        self._last_signal_ver = ver
+        self._last_indicator = (meta or {}).get("indicator") or "-"
+
+        sig_symbol = (meta or {}).get("symbol") or self.symbol
+        sig_tf = (meta or {}).get("timeframe") or self.timeframe
+        if self._use_any_symbol:
+            self.symbol = sig_symbol
+        if self._use_any_timeframe:
+            self.timeframe = sig_tf
+            self.params["timeframe"] = self.timeframe
+        if self._use_any_symbol or self._use_any_timeframe:
+            raw_minutes = _minutes_from_timeframe(self.timeframe)
+            norm = normalize_sprint(self.symbol, raw_minutes)
+            if norm is None:
+                fallback = raw_minutes
+                norm = normalize_sprint(self.symbol, fallback) or fallback
+                if self.log:
+                    self.log(
+                        f"[{self.symbol}] ⚠ Минуты {raw_minutes} недопустимы. Использую {norm}."
+                    )
+            self._trade_minutes = int(norm)
+            self.params["minutes"] = self._trade_minutes
+
+        from datetime import datetime
+
+        self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+        return int(direction)
+
+    def update_params(self, **params):
+        super().update_params(**params)
+
+        if "minutes" in params:
+            try:
+                requested = int(params["minutes"])
+            except Exception:
+                return
+            norm = normalize_sprint(self.symbol, requested)
+            if norm is None:
+                if self.symbol == "BTCUSDT":
+                    norm = 5 if requested < 5 else 500
+                else:
+                    norm = 1 if requested < 3 else max(3, min(500, requested))
+                if self.log:
+                    self.log(
+                        f"[{self.symbol}] ⚠ Минуты {requested} недопустимы. Исправлено на {norm}."
+                    )
+            self._trade_minutes = int(norm)
+            self.params["minutes"] = self._trade_minutes
+
+        if "timeframe" in params:
+            tf_raw = str(params["timeframe"]).strip()
+            tf = tf_raw.upper()
+            self._use_any_timeframe = tf_raw in (ALL_TF_LABEL, "*")
+            self.timeframe = "*" if self._use_any_timeframe else tf
+            self.params["timeframe"] = self.timeframe
+            if self.timeframe != "*" and "minutes" not in params:
+                self._trade_minutes = _minutes_from_timeframe(self.timeframe)
+
+        if "account_currency" in params:
+            want = str(params["account_currency"]).upper()
+            if want != self._anchor_ccy and self.log:
+                self.log(
+                    f"[{self.symbol}] ⚠ Игнорирую попытку сменить валюту на лету {self._anchor_ccy} → {want}. Валюта зафиксирована при создании."
+                )
+            self.params["account_currency"] = self._anchor_ccy
+
+    async def _ensure_anchor_currency(self) -> bool:
+        try:
+            _, ccy_now, _ = await get_balance_info(
+                self.http_client, self.user_id, self.user_hash
+            )
+        except Exception:
+            ccy_now = None
+        if ccy_now != self._anchor_ccy:
+            self._status(f"ожидание смены валюты на {self._anchor_ccy}")
+            await self.sleep(1.0)
+            return False
+        return True
+
+    async def _ensure_anchor_account_mode(self) -> bool:
+        try:
+            demo_now = await is_demo_account(self.http_client)
+        except Exception:
+            self._status("ожидание проверки режима счёта")
+            await self.sleep(1.0)
+            return False
+
+        if self._anchor_is_demo is None:
+            self._anchor_is_demo = bool(demo_now)
+
+        if bool(demo_now) != bool(self._anchor_is_demo):
+            need = "ДЕМО" if self._anchor_is_demo else "РЕАЛ"
+            self._status(f"ожидание смены счёта на {need}")
+            await self.sleep(1.0)
+            return False
+        return True
+


### PR DESCRIPTION
## Summary
- add FixedStakeStrategy that places constant stakes on incoming signals
- create settings dialog for configuring fixed stake parameters
- register Fixed Stake strategy across UI components

## Testing
- `python -m py_compile strategies/fixed.py gui/settings_fixed.py gui/settings_factory.py gui/main_window.py gui/strategy_control_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_68aff332631c8322938e449eadeae6d8