### PR TITLE
Add classic trade type with time and date support

### DIFF
--- a/core/intrade_api.py
+++ b/core/intrade_api.py
@@ -158,38 +158,43 @@ def place_trade(
     investment,
     option,  # символ, напр. "EURUSD" / "BTCUSDT"
     status,  # 1/2
-    minutes,  # строка или int
+    minutes,  # строка (HH:MM) или int
     *,
     account_ccy: str = DEFAULT_ACCOUNT_CCY,
     strict: bool = True,
     on_log=None,
+    trade_type: str = "sprint",
+    date: str = "0",
 ):
     """
     strict=True  -> при нарушении правил возвращает None (не отправляет запрос).
     strict=False -> ставка будет поджата к лимитам, но недопустимое время спринта всё равно запрещаем.
     """
 
-    # ---- Валидация времени спринта
-    try:
-        m = int(minutes)
-    except Exception:
-        if on_log:
-            on_log(f"[{option}] ❌ Некорректное значение минут: {minutes}")
-        return None
+    if str(trade_type).lower() == "classic":
+        time_value = str(minutes)
+    else:
+        # ---- Валидация времени спринта
+        try:
+            m = int(minutes)
+        except Exception:
+            if on_log:
+                on_log(f"[{option}] ❌ Некорректное значение минут: {minutes}")
+            return None
 
-    norm_m = normalize_sprint(option, m)
-    if norm_m is None:
-        if on_log:
-            if option == "BTCUSDT":
-                on_log(
-                    f"[{option}] 🚫 Недопустимое время спринта: {m} мин. Разрешено 5–500."
-                )
-            else:
-                on_log(
-                    f"[{option}] 🚫 Недопустимое время спринта: {m} мин. Разрешено 1 или 3–500."
-                )
-        return None
-    minutes = str(norm_m)
+        norm_m = normalize_sprint(option, m)
+        if norm_m is None:
+            if on_log:
+                if option == "BTCUSDT":
+                    on_log(
+                        f"[{option}] 🚫 Недопустимое время спринта: {m} мин. Разрешено 5–500."
+                    )
+                else:
+                    on_log(
+                        f"[{option}] 🚫 Недопустимое время спринта: {m} мин. Разрешено 1 или 3–500."
+                    )
+            return None
+        time_value = str(norm_m)
 
     # ---- Валидация/приведение суммы ставки
     try:
@@ -220,9 +225,9 @@ def place_trade(
         "user_hash": user_hash,
         "option": option,
         "investment": investment,
-        "time": minutes,
-        "date": "0",
-        "trade_type": "sprint",
+        "time": time_value,
+        "date": date,
+        "trade_type": str(trade_type),
         "status": str(status),
     }
     r = session.post(TRADE_URL, data=payload)

--- a/core/intrade_api_async.py
+++ b/core/intrade_api_async.py
@@ -99,40 +99,45 @@ async def place_trade(
     investment: float | int | str,
     option: str,
     status: int,  # 1/2
-    minutes: int | str,  # минуты
+    minutes: int | str,  # минуты или HH:MM
     *,
     account_ccy: str = DEFAULT_ACCOUNT_CCY,
     strict: bool = True,
     on_log=None,
+    trade_type: str = "sprint",
+    date: str = "0",
 ) -> Optional[str]:
     """
     Полная проверка, как в sync-версии:
-      - нормализация времени спринта
+      - нормализация времени спринта (для sprint)
       - привод к лимитам суммы
       - POST и парсинг HTML ответа для data-id
     Возвращает trade_id или None.
     """
-    # --- время спринта
-    try:
-        m = int(minutes)
-    except Exception:
-        if on_log:
-            on_log(f"[{option}] ❌ Некорректное значение минут: {minutes}")
-        return None
+    if str(trade_type).lower() == "classic":
+        time_value = str(minutes)
+    else:
+        # --- время спринта
+        try:
+            m = int(minutes)
+        except Exception:
+            if on_log:
+                on_log(f"[{option}] ❌ Некорректное значение минут: {minutes}")
+            return None
 
-    norm_m = normalize_sprint(option, m)
-    if norm_m is None:
-        if on_log:
-            if option == "BTCUSDT":
-                on_log(
-                    f"[{option}] 🚫 Недопустимое время спринта: {m} мин. Разрешено 5–500."
-                )
-            else:
-                on_log(
-                    f"[{option}] 🚫 Недопустимое время спринта: {m} мин. Разрешено 1 или 3–500."
-                )
-        return None
-    minutes = str(norm_m)
+        norm_m = normalize_sprint(option, m)
+        if norm_m is None:
+            if on_log:
+                if option == "BTCUSDT":
+                    on_log(
+                        f"[{option}] 🚫 Недопустимое время спринта: {m} мин. Разрешено 5–500."
+                    )
+                else:
+                    on_log(
+                        f"[{option}] 🚫 Недопустимое время спринта: {m} мин. Разрешено 1 или 3–500."
+                    )
+            return None
+        time_value = str(norm_m)
 
     # --- сумма
     try:
@@ -163,9 +168,9 @@ async def place_trade(
         "user_hash": user_hash,
         "option": option.replace("/", ""),
         "investment": investment,
-        "time": minutes,
-        "date": "0",
-        "trade_type": "sprint",
+        "time": time_value,
+        "date": date,
+        "trade_type": str(trade_type),
         "status": str(status),
     }
     html = await client.post(PATH_TRADE, data=payload, expect_json=False)

--- a/core/signal_waiter.py
+++ b/core/signal_waiter.py
@@ -3,6 +3,7 @@ import asyncio
 from dataclasses import dataclass, field
 from collections import defaultdict
 from typing import Optional, Tuple, Dict, Callable, Awaitable
+from datetime import datetime
 
 
 # --- helpers ---------------------------------------------------------
@@ -47,6 +48,7 @@ class _State:
     # для wildcard-ожидателей запоминаем исходный символ/таймфрейм
     last_symbol: Optional[str] = None
     last_timeframe: Optional[str] = None
+    next_timestamp: Optional[datetime] = None  # начало следующей свечи
 
 
 _states: Dict[tuple[str, str], _State] = defaultdict(_State)
@@ -68,6 +70,7 @@ def push_signal(
     timeframe: str,
     direction: Optional[int],
     indicator: Optional[str] = None,
+    next_timestamp: Optional[datetime] = None,
 ) -> None:
     """
     Положить НОВОЕ сообщение сигнала:
@@ -95,6 +98,7 @@ def push_signal(
                 st.last_indicator = indicator
             st.last_symbol = symbol
             st.last_timeframe = timeframe
+            st.next_timestamp = next_timestamp
             st.cond.notify_all()
 
     loop = asyncio.get_running_loop()
@@ -193,15 +197,16 @@ async def wait_for_signal_versioned(
             and st.last_monotonic is not None
             and st.last_monotonic >= start
         ):
-            if include_meta:
-                meta = {
-                    "indicator": st.last_indicator,
-                    "tf_sec": st.tf_sec,
-                    "symbol": st.last_symbol,
-                    "timeframe": st.last_timeframe,
-                }
-                return int(direction), int(ver), meta
-            return int(direction), int(ver)
+                if include_meta:
+                    meta = {
+                        "indicator": st.last_indicator,
+                        "tf_sec": st.tf_sec,
+                        "symbol": st.last_symbol,
+                        "timeframe": st.last_timeframe,
+                        "next_timestamp": st.next_timestamp,
+                    }
+                    return int(direction), int(ver), meta
+                return int(direction), int(ver)
         # иначе ждём следующего уведомления
 
 
@@ -229,7 +234,7 @@ async def wait_for_signal(
 
 def peek_signal_state(
     symbol: str, timeframe: str
-) -> Dict[str, Optional[int | float | str]]:
+) -> Dict[str, Optional[int | float | str | datetime]]:
     """
     Неблокирующий доступ к текущему состоянию: возвращает dict с полями:
       version, value (1/2/None), indicator (str|None), tf_sec (int|None), last_monotonic (float|None)
@@ -241,4 +246,5 @@ def peek_signal_state(
         "indicator": st.last_indicator,
         "tf_sec": st.tf_sec,
         "last_monotonic": st.last_monotonic,
+        "next_timestamp": st.next_timestamp,
     }

--- a/core/ws_client.py
+++ b/core/ws_client.py
@@ -130,8 +130,14 @@ async def listen_to_signals() -> None:
                     if sig is None:
                         continue
 
-                    # Отправляем в ожидатель — сигнатура без изменений
-                    push_signal(sig.symbol, sig.timeframe, sig.direction, sig.indicator)
+                    # Отправляем в ожидатель
+                    push_signal(
+                        sig.symbol,
+                        sig.timeframe,
+                        sig.direction,
+                        sig.indicator,
+                        sig.next_timestamp,
+                    )
 
                     # Лог: время без таймзоны (локально-наивное)
                     dt_naive = sig.timestamp.replace(tzinfo=None)

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -15,6 +15,7 @@ from PyQt6.QtWidgets import (
     QTableWidget,
     QTableWidgetItem,
     QHeaderView,
+    QComboBox,
 )
 from PyQt6.QtGui import QColor, QBrush
 from PyQt6.QtCore import QTimer, Qt
@@ -118,6 +119,18 @@ class StrategyControlDialog(QDialog):
         tf = str(getv("timeframe", self.bot.strategy_kwargs.get("timeframe", "M1")))
         default_minutes = int(getv("minutes", _minutes_from_timeframe(tf)))
 
+        self.trade_type = QComboBox()
+        self.trade_type.addItems(["sprint", "classic"])
+        self.trade_type.setCurrentText(str(getv("trade_type", "sprint")))
+        allowed_classic = {"M5", "M15", "M30", "H1", "H4"}
+        if tf not in allowed_classic:
+            idx = self.trade_type.findText("classic")
+            if idx >= 0:
+                item = self.trade_type.model().item(idx)
+                item.setEnabled(False)
+            if self.trade_type.currentText() == "classic":
+                self.trade_type.setCurrentText("sprint")
+
         strategy_key = str(self.bot.strategy_kwargs.get("strategy_key", "")).lower()
         self.strategy_key = strategy_key
 
@@ -159,6 +172,7 @@ class StrategyControlDialog(QDialog):
             form.addRow("Базовая ставка", self.base_investment)
             form.addRow("Цель серии, прибыль", self.target_profit)
             form.addRow("Время сделки (мин)", self.minutes)
+            form.addRow("Тип торговли", self.trade_type)
             form.addRow("Макс. сделок в серии", self.max_steps)
             form.addRow("Повторов серии", self.repeat_count)
             form.addRow("Мин. баланс", self.min_balance)
@@ -188,6 +202,7 @@ class StrategyControlDialog(QDialog):
 
             form.addRow("Базовая ставка", self.base_investment)
             form.addRow("Время сделки (мин)", self.minutes)
+            form.addRow("Тип торговли", self.trade_type)
             form.addRow("Количество ставок", self.repeat_count)
             form.addRow("Мин. баланс", self.min_balance)
             form.addRow("Мин. процент", self.min_percent)
@@ -220,6 +235,7 @@ class StrategyControlDialog(QDialog):
 
             form.addRow("Базовая ставка", self.base_investment)
             form.addRow("Время сделки (мин)", self.minutes)
+            form.addRow("Тип торговли", self.trade_type)
             form.addRow("Макс. шагов", self.max_steps)
             form.addRow("Повторов серии", self.repeat_count)
             form.addRow("Мин. баланс", self.min_balance)
@@ -415,6 +431,7 @@ class StrategyControlDialog(QDialog):
                 "min_percent": self.min_percent.value(),
                 "minutes": int(norm),
             }
+        new_params["trade_type"] = self.trade_type.currentText()
 
         self.bot.strategy_kwargs.setdefault("params", {}).update(new_params)
         if self.bot.strategy and hasattr(self.bot.strategy, "update_params"):

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -30,6 +30,7 @@ DEFAULTS = {
     "account_currency": "RUB",
     "result_wait_s": 60.0,
     "grace_delay_sec": 30.0,
+    "trade_type": "sprint",
 }
 
 
@@ -112,6 +113,9 @@ class AntiMartingaleStrategy(StrategyBase):
         self._trade_minutes = int(norm)
         self.params["minutes"] = self._trade_minutes
 
+        self._trade_type = str(self.params.get("trade_type", "sprint")).lower()
+        self.params["trade_type"] = self._trade_type
+
         self._on_trade_result = self.params.get("on_trade_result")
         self._on_trade_pending = self.params.get("on_trade_pending")
         self._on_status = self.params.get("on_status")
@@ -130,6 +134,7 @@ class AntiMartingaleStrategy(StrategyBase):
         self._last_signal_ver: Optional[int] = None
         self._last_indicator: str = "-"
         self._last_signal_at_str: Optional[str] = None
+        self._next_expire_dt = None
 
         anchor = str(
             self.params.get("account_currency", DEFAULTS["account_currency"])
@@ -334,6 +339,17 @@ class AntiMartingaleStrategy(StrategyBase):
                 account_mode = "ДЕМО" if demo_now else "РЕАЛ"
 
                 self._status("делает ставку")
+                trade_kwargs = {"trade_type": self._trade_type}
+                time_arg = self._trade_minutes
+                if self._trade_type == "classic":
+                    if not self._next_expire_dt:
+                        log(
+                            f"[{self.symbol}] ❌ Нет времени экспирации для classic. Пауза и повтор."
+                        )
+                        await self.sleep(1.0)
+                        continue
+                    time_arg = self._next_expire_dt.strftime("%H:%M")
+                    trade_kwargs["date"] = self._next_expire_dt.strftime("%d-%m-%Y")
                 trade_id = await place_trade(
                     self.http_client,
                     user_id=self.user_id,
@@ -341,10 +357,11 @@ class AntiMartingaleStrategy(StrategyBase):
                     investment=stake,
                     option=self.symbol,
                     status=status,
-                    minutes=self._trade_minutes,
+                    minutes=time_arg,
                     account_ccy=account_ccy,
                     strict=True,
                     on_log=log,
+                    **trade_kwargs,
                 )
                 if not trade_id:
                     log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
@@ -501,6 +518,8 @@ class AntiMartingaleStrategy(StrategyBase):
         self._last_signal_ver = ver
         self._last_indicator = (meta or {}).get("indicator") or "-"
 
+        self._next_expire_dt = (meta or {}).get("next_timestamp")
+
         sig_symbol = (meta or {}).get("symbol") or self.symbol
         sig_tf = (meta or {}).get("timeframe") or self.timeframe
         if self._use_any_symbol:
@@ -564,3 +583,7 @@ class AntiMartingaleStrategy(StrategyBase):
                     f"{self._anchor_ccy} → {want}. Валюта зафиксирована при создании."
                 )
             self.params["account_currency"] = self._anchor_ccy
+
+        if "trade_type" in params:
+            self._trade_type = str(params["trade_type"]).lower()
+            self.params["trade_type"] = self._trade_type

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -269,6 +269,17 @@ class FibonacciStrategy(MartingaleStrategy):
                 account_mode = "ДЕМО" if demo_now else "РЕАЛ"
 
                 self._status("делает ставку")
+                trade_kwargs = {"trade_type": self._trade_type}
+                time_arg = self._trade_minutes
+                if self._trade_type == "classic":
+                    if not self._next_expire_dt:
+                        log(
+                            f"[{self.symbol}] ❌ Нет времени экспирации для classic. Пауза и повтор."
+                        )
+                        await self.sleep(1.0)
+                        continue
+                    time_arg = self._next_expire_dt.strftime("%H:%M")
+                    trade_kwargs["date"] = self._next_expire_dt.strftime("%d-%m-%Y")
                 trade_id = await place_trade(
                     self.http_client,
                     user_id=self.user_id,
@@ -276,10 +287,11 @@ class FibonacciStrategy(MartingaleStrategy):
                     investment=stake,
                     option=self.symbol,
                     status=status,
-                    minutes=self._trade_minutes,
+                    minutes=time_arg,
                     account_ccy=account_ccy,
                     strict=True,
                     on_log=log,
+                    **trade_kwargs,
                 )
                 if not trade_id:
                     log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -30,6 +30,7 @@ DEFAULTS = {
     "account_currency": "RUB",
     "result_wait_s": 60.0,
     "grace_delay_sec": 30.0,
+    "trade_type": "sprint",
 }
 
 
@@ -107,6 +108,9 @@ class FixedStakeStrategy(StrategyBase):
         self._trade_minutes = int(norm)
         self.params["minutes"] = self._trade_minutes
 
+        self._trade_type = str(self.params.get("trade_type", "sprint")).lower()
+        self.params["trade_type"] = self._trade_type
+
         self._on_trade_result = self.params.get("on_trade_result")
         self._on_trade_pending = self.params.get("on_trade_pending")
         self._on_status = self.params.get("on_status")
@@ -125,6 +129,7 @@ class FixedStakeStrategy(StrategyBase):
         self._last_signal_ver: Optional[int] = None
         self._last_indicator: str = "-"
         self._last_signal_at_str: Optional[str] = None
+        self._next_expire_dt = None
 
         anchor = str(
             self.params.get("account_currency", DEFAULTS["account_currency"])
@@ -320,6 +325,17 @@ class FixedStakeStrategy(StrategyBase):
             account_mode = "ДЕМО" if demo_now else "РЕАЛ"
 
             self._status("делает ставку")
+            trade_kwargs = {"trade_type": self._trade_type}
+            time_arg = self._trade_minutes
+            if self._trade_type == "classic":
+                if not self._next_expire_dt:
+                    log(
+                        f"[{self.symbol}] ❌ Нет времени экспирации для classic. Пауза и повтор."
+                    )
+                    await self.sleep(1.0)
+                    continue
+                time_arg = self._next_expire_dt.strftime("%H:%M")
+                trade_kwargs["date"] = self._next_expire_dt.strftime("%d-%m-%Y")
             trade_id = await place_trade(
                 self.http_client,
                 user_id=self.user_id,
@@ -327,10 +343,11 @@ class FixedStakeStrategy(StrategyBase):
                 investment=stake,
                 option=self.symbol,
                 status=status,
-                minutes=self._trade_minutes,
+                minutes=time_arg,
                 account_ccy=account_ccy,
                 strict=True,
                 on_log=log,
+                **trade_kwargs,
             )
             if not trade_id:
                 log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
@@ -431,6 +448,8 @@ class FixedStakeStrategy(StrategyBase):
         self._last_signal_ver = ver
         self._last_indicator = (meta or {}).get("indicator") or "-"
 
+        self._next_expire_dt = (meta or {}).get("next_timestamp")
+
         sig_symbol = (meta or {}).get("symbol") or self.symbol
         sig_tf = (meta or {}).get("timeframe") or self.timeframe
         if self._use_any_symbol:
@@ -493,6 +512,10 @@ class FixedStakeStrategy(StrategyBase):
                     f"[{self.symbol}] ⚠ Игнорирую попытку сменить валюту на лету {self._anchor_ccy} → {want}. Валюта зафиксирована при создании."
                 )
             self.params["account_currency"] = self._anchor_ccy
+
+        if "trade_type" in params:
+            self._trade_type = str(params["trade_type"]).lower()
+            self.params["trade_type"] = self._trade_type
 
     async def _ensure_anchor_currency(self) -> bool:
         try:

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -32,6 +32,7 @@ DEFAULTS = {
     "account_currency": "RUB",
     "result_wait_s": 60.0,
     "grace_delay_sec": 30.0,
+    "trade_type": "sprint",
 }
 
 
@@ -114,6 +115,9 @@ class MartingaleStrategy(StrategyBase):
         self._trade_minutes = int(norm)
         self.params["minutes"] = self._trade_minutes
 
+        self._trade_type = str(self.params.get("trade_type", "sprint")).lower()
+        self.params["trade_type"] = self._trade_type
+
         self._on_trade_result = self.params.get("on_trade_result")
         self._on_trade_pending = self.params.get("on_trade_pending")
         self._on_status = self.params.get("on_status")
@@ -134,6 +138,7 @@ class MartingaleStrategy(StrategyBase):
         self._last_signal_at_str: Optional[str] = (
             None  # <=== НОВОЕ: время прихода сигнала
         )
+        self._next_expire_dt = None
 
         anchor = str(
             self.params.get("account_currency", DEFAULTS["account_currency"])
@@ -340,6 +345,17 @@ class MartingaleStrategy(StrategyBase):
 
                 # --- размещаем сделку ---
                 self._status("делает ставку")
+                trade_kwargs = {"trade_type": self._trade_type}
+                time_arg = self._trade_minutes
+                if self._trade_type == "classic":
+                    if not self._next_expire_dt:
+                        log(
+                            f"[{self.symbol}] ❌ Нет времени экспирации для classic. Пауза и повтор."
+                        )
+                        await self.sleep(1.0)
+                        continue
+                    time_arg = self._next_expire_dt.strftime("%H:%M")
+                    trade_kwargs["date"] = self._next_expire_dt.strftime("%d-%m-%Y")
                 trade_id = await place_trade(
                     self.http_client,
                     user_id=self.user_id,
@@ -347,10 +363,11 @@ class MartingaleStrategy(StrategyBase):
                     investment=stake,
                     option=self.symbol,
                     status=status,
-                    minutes=self._trade_minutes,
+                    minutes=time_arg,
                     account_ccy=account_ccy,
                     strict=True,
                     on_log=log,
+                    **trade_kwargs,
                 )
                 if not trade_id:
                     log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
@@ -508,6 +525,8 @@ class MartingaleStrategy(StrategyBase):
         self._last_signal_ver = ver
         self._last_indicator = (meta or {}).get("indicator") or "-"
 
+        self._next_expire_dt = (meta or {}).get("next_timestamp")
+
         sig_symbol = (meta or {}).get("symbol") or self.symbol
         sig_tf = (meta or {}).get("timeframe") or self.timeframe
         if self._use_any_symbol:
@@ -571,3 +590,7 @@ class MartingaleStrategy(StrategyBase):
                     f"{self._anchor_ccy} → {want}. Валюта зафиксирована при создании."
                 )
             self.params["account_currency"] = self._anchor_ccy
+
+        if "trade_type" in params:
+            self._trade_type = str(params["trade_type"]).lower()
+            self.params["trade_type"] = self._trade_type

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -45,6 +45,7 @@ DEFAULTS = {
     "grace_delay_sec": 30.0,
     # Поведение серии: фиксировать направление по первому сигналу (как в мартингейле)
     "lock_direction_to_first": True,
+    "trade_type": "sprint",
 }
 
 
@@ -113,6 +114,9 @@ class OscarGrind2Strategy(StrategyBase):
         self._trade_minutes = int(norm)
         self.params["minutes"] = self._trade_minutes
 
+        self._trade_type = str(self.params.get("trade_type", "sprint")).lower()
+        self.params["trade_type"] = self._trade_type
+
         self._on_trade_result = self.params.get("on_trade_result")
         self._on_trade_pending = self.params.get("on_trade_pending")
         self._on_status = self.params.get("on_status")
@@ -131,6 +135,7 @@ class OscarGrind2Strategy(StrategyBase):
         self._last_signal_ver: Optional[int] = None
         self._last_indicator: str = "-"
         self._last_signal_at_str: Optional[str] = None
+        self._next_expire_dt = None
 
         anchor = str(
             self.params.get("account_currency", DEFAULTS["account_currency"])
@@ -352,6 +357,17 @@ class OscarGrind2Strategy(StrategyBase):
 
                 # --- размещаем сделку ---
                 self._status("делает ставку")
+                trade_kwargs = {"trade_type": self._trade_type}
+                time_arg = self._trade_minutes
+                if self._trade_type == "classic":
+                    if not self._next_expire_dt:
+                        log(
+                            f"[{self.symbol}] ❌ Нет времени экспирации для classic. Пауза и повтор."
+                        )
+                        await self.sleep(1.0)
+                        continue
+                    time_arg = self._next_expire_dt.strftime("%H:%M")
+                    trade_kwargs["date"] = self._next_expire_dt.strftime("%d-%m-%Y")
                 trade_id = await place_trade(
                     self.http_client,
                     user_id=self.user_id,
@@ -359,10 +375,11 @@ class OscarGrind2Strategy(StrategyBase):
                     investment=stake,
                     option=self.symbol,
                     status=status,
-                    minutes=self._trade_minutes,
+                    minutes=time_arg,
                     account_ccy=account_ccy,
                     strict=True,
                     on_log=log,
+                    **trade_kwargs,
                 )
                 if not trade_id:
                     log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
@@ -575,6 +592,8 @@ class OscarGrind2Strategy(StrategyBase):
         self._last_signal_ver = ver
         self._last_indicator = (meta or {}).get("indicator") or "-"
 
+        self._next_expire_dt = (meta or {}).get("next_timestamp")
+
         sig_symbol = (meta or {}).get("symbol") or self.symbol
         sig_tf = (meta or {}).get("timeframe") or self.timeframe
         if self._use_any_symbol:
@@ -638,6 +657,10 @@ class OscarGrind2Strategy(StrategyBase):
                     f"{self._anchor_ccy} → {want}. Валюта зафиксирована при создании."
                 )
             self.params["account_currency"] = self._anchor_ccy
+
+        if "trade_type" in params:
+            self._trade_type = str(params["trade_type"]).lower()
+            self.params["trade_type"] = self._trade_type
 
         if "base_investment" in params and "target_profit" not in params:
             # если юзер поменял unit, а цель оставил None — синхронизируем цель с unit


### PR DESCRIPTION
## Summary
- Add `trade_type` and time/date handling to `place_trade` for classic trades
- Pass next candle timestamp through signal pipeline and expose in GUI
- Allow selecting trade type in strategy control dialog and update strategies accordingly

## Testing
- `python -m py_compile core/intrade_api_async.py core/intrade_api.py core/signal_waiter.py core/ws_client.py gui/strategy_control_dialog.py strategies/martingale.py strategies/fixed.py strategies/oscar_grind_2.py strategies/antimartin.py strategies/fibonacci.py`

------
https://chatgpt.com/codex/tasks/task_e_68b04ec1fd448322bcf9a5a5564ab890