### PR TITLE
Handle wildcard signals before payout

### DIFF
--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -258,6 +258,20 @@ class AntiMartingaleStrategy(StrategyBase):
                     continue
                 if not await self._ensure_anchor_account_mode():
                     continue
+                status = None
+                if self.symbol == "*" or self.timeframe == "*":
+                    self._status("ожидание сигнала")
+                    log(
+                        f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe} (шаг {step})..."
+                    )
+                    try:
+                        direction = await self.wait_signal(timeout=sig_timeout)
+                    except asyncio.TimeoutError:
+                        log(
+                            f"[{self.symbol}] ⌛ Таймаут ожидания сигнала внутри серии — выхожу из серии."
+                        )
+                        break
+                    status = 1 if int(direction) == 1 else 2
 
                 pct = await get_current_percent(
                     self.http_client,
@@ -286,18 +300,19 @@ class AntiMartingaleStrategy(StrategyBase):
                     )
                     self._low_payout_notified = False
 
-                self._status("ожидание сигнала")
-                log(
-                    f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe} (шаг {step})..."
-                )
-                try:
-                    direction = await self.wait_signal(timeout=sig_timeout)
-                except asyncio.TimeoutError:
+                if status is None:
+                    self._status("ожидание сигнала")
                     log(
-                        f"[{self.symbol}] ⌛ Таймаут ожидания сигнала внутри серии — выхожу из серии."
+                        f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe} (шаг {step})..."
                     )
-                    break
-                status = 1 if int(direction) == 1 else 2
+                    try:
+                        direction = await self.wait_signal(timeout=sig_timeout)
+                    except asyncio.TimeoutError:
+                        log(
+                            f"[{self.symbol}] ⌛ Таймаут ожидания сигнала внутри серии — выхожу из серии."
+                        )
+                        break
+                    status = 1 if int(direction) == 1 else 2
 
                 try:
                     cur_balance, _, _ = await get_balance_info(

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -186,6 +186,22 @@ class FibonacciStrategy(MartingaleStrategy):
 
                 stake = base * _fib(step)
 
+                if series_direction is None and (
+                    self.symbol == "*" or self.timeframe == "*"
+                ):
+                    self._status("ожидание сигнала")
+                    log(
+                        f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe} (шаг {step})..."
+                    )
+                    try:
+                        direction = await self.wait_signal(timeout=sig_timeout)
+                    except asyncio.TimeoutError:
+                        log(
+                            f"[{self.symbol}] ⌛ Таймаут ожидания сигнала внутри серии — выхожу из серии."
+                        )
+                        break
+                    series_direction = 1 if int(direction) == 1 else 2
+
                 pct = await get_current_percent(
                     self.http_client,
                     investment=stake,

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -231,6 +231,22 @@ class FixedStakeStrategy(StrategyBase):
             )
             account_ccy = self._anchor_ccy
 
+            status = None
+            if self.symbol == "*" or self.timeframe == "*":
+                self._status("ожидание сигнала")
+                log(
+                    f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe}..."
+                )
+                try:
+                    direction = await self.wait_signal(timeout=sig_timeout)
+                except asyncio.TimeoutError:
+                    log(
+                        f"[{self.symbol}] ⌛ Таймаут ожидания сигнала — повтор."
+                    )
+                    await self.sleep(1.0)
+                    continue
+                status = 1 if int(direction) == 1 else 2
+
             try:
                 pct = await get_current_percent(
                     self.http_client,
@@ -270,21 +286,20 @@ class FixedStakeStrategy(StrategyBase):
                 log(f"[{self.symbol}] ℹ Работа продолжается (текущий payout = {pct}%)")
                 self._low_payout_notified = False
 
-            self._status("ожидание сигнала")
-            log(
-                f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe}..."
-            )
-
-            try:
-                direction = await self.wait_signal(timeout=sig_timeout)
-            except asyncio.TimeoutError:
+            if status is None:
+                self._status("ожидание сигнала")
                 log(
-                    f"[{self.symbol}] ⌛ Таймаут ожидания сигнала — повтор."
+                    f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe}..."
                 )
-                await self.sleep(1.0)
-                continue
-
-            status = 1 if int(direction) == 1 else 2
+                try:
+                    direction = await self.wait_signal(timeout=sig_timeout)
+                except asyncio.TimeoutError:
+                    log(
+                        f"[{self.symbol}] ⌛ Таймаут ожидания сигнала — повтор."
+                    )
+                    await self.sleep(1.0)
+                    continue
+                status = 1 if int(direction) == 1 else 2
 
             try:
                 cur_balance, _, _ = await get_balance_info(

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -259,6 +259,22 @@ class MartingaleStrategy(StrategyBase):
                 if not await self._ensure_anchor_account_mode():
                     continue
 
+                if series_direction is None and (
+                    self.symbol == "*" or self.timeframe == "*"
+                ):
+                    self._status("ожидание сигнала")
+                    log(
+                        f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe} (шаг {step})..."
+                    )
+                    try:
+                        direction = await self.wait_signal(timeout=sig_timeout)
+                    except asyncio.TimeoutError:
+                        log(
+                            f"[{self.symbol}] ⌛ Таймаут ожидания сигнала внутри серии — выхожу из серии."
+                        )
+                        break
+                    series_direction = 1 if int(direction) == 1 else 2
+
                 # payout
                 pct = await get_current_percent(
                     self.http_client,

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -271,6 +271,25 @@ class OscarGrind2Strategy(StrategyBase):
                 if not await self._ensure_anchor_account_mode():
                     continue
 
+                got_signal_early = False
+
+                if series_direction is None and (
+                    self.symbol == "*" or self.timeframe == "*"
+                ):
+                    self._status("ожидание сигнала")
+                    log(
+                        f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe} (шаг {step_idx + 1})..."
+                    )
+                    try:
+                        direction = await self.wait_signal(timeout=sig_timeout)
+                    except asyncio.TimeoutError:
+                        log(
+                            f"[{self.symbol}] ⌛ Таймаут ожидания сигнала внутри серии — выхожу из серии."
+                        )
+                        break
+                    series_direction = 1 if int(direction) == 1 else 2
+                    got_signal_early = True
+
                 # Узнаём payout на текущую ставку
                 pct = await get_current_percent(
                     self.http_client,
@@ -300,7 +319,7 @@ class OscarGrind2Strategy(StrategyBase):
                     self._low_payout_notified = False
 
                 # Получаем (или переиспользуем) направление
-                if series_direction is None or not lock_dir:
+                if series_direction is None or (not lock_dir and not got_signal_early):
                     self._status("ожидание сигнала")
                     log(
                         f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe} (шаг {step_idx + 1})..."


### PR DESCRIPTION
## Summary
- Wait for a trading signal before requesting payout percent when the symbol or timeframe is unspecified
- Apply the same early-signal handling across all strategies to avoid repeated `Не получили % выплаты` messages

## Testing
- `python -m py_compile strategies/martingale.py strategies/fibonacci.py strategies/fixed.py strategies/oscar_grind_2.py strategies/antimartin.py`


------
https://chatgpt.com/codex/tasks/task_e_68b057fb60e48322ad5e235928d6bb0c