### PR TITLE
Handle Classic trade percent and expiry

### DIFF
--- a/core/intrade_api.py
+++ b/core/intrade_api.py
@@ -131,19 +131,21 @@ def get_account_currency(session, user_id, user_hash) -> str:
     return currency
 
 
-def get_current_percent(session, investment, option, minutes=1, account_ccy="RUB"):
+def get_current_percent(session, investment, option, minutes=1, account_ccy="RUB", trade_type="sprint"):
     """
     Получить текущий процент под заданную ставку/время/символ.
     minutes/ccy необязательны — оставлены для совместимости.
     """
+    t = "Classic" if str(trade_type).lower() == "classic" else "Sprint"
     payload = {
-        "type": "Sprint",
-        "time": str(int(minutes)),
+        "type": t,
         "currency_name": account_ccy,  # раньше было жестко "RUB"
         "investment": str(investment),
         "percent": "",
         "option": option,
     }
+    if str(trade_type).lower() != "classic":
+        payload["time"] = str(int(minutes))
     r = session.post(PERCENT_URL, data=payload)
     try:
         return int(r.text.strip())

--- a/core/intrade_api_async.py
+++ b/core/intrade_api_async.py
@@ -70,18 +70,21 @@ async def get_current_percent(
     option: str,
     minutes: int | str = 1,
     account_ccy: str = "RUB",
+    trade_type: str = "sprint",
 ) -> Optional[int]:
     """
     Совместимая версия: отправляет form-data как sync, возвращает int|None.
     """
+    t = "Classic" if str(trade_type).lower() == "classic" else "Sprint"
     payload = {
-        "type": "Sprint",
-        "time": str(int(minutes)),
+        "type": t,
         "currency_name": account_ccy,
         "investment": str(investment),
         "percent": "",
         "option": option,
     }
+    if str(trade_type).lower() != "classic":
+        payload["time"] = str(int(minutes))
     text = await client.post(PATH_PERCENT, data=payload, expect_json=False)
     try:
         return int(str(text).strip())

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -265,6 +265,7 @@ class AntiMartingaleStrategy(StrategyBase):
                     option=self.symbol,
                     minutes=self._trade_minutes,
                     account_ccy=account_ccy,
+                    trade_type=self._trade_type,
                 )
                 if pct is None:
                     self._status("ожидание процента")
@@ -518,7 +519,8 @@ class AntiMartingaleStrategy(StrategyBase):
         self._last_signal_ver = ver
         self._last_indicator = (meta or {}).get("indicator") or "-"
 
-        self._next_expire_dt = (meta or {}).get("next_timestamp")
+        ts = (meta or {}).get("next_timestamp")
+        self._next_expire_dt = ts.astimezone().replace(tzinfo=None) if ts else None
 
         sig_symbol = (meta or {}).get("symbol") or self.symbol
         sig_tf = (meta or {}).get("timeframe") or self.timeframe

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -192,6 +192,7 @@ class FibonacciStrategy(MartingaleStrategy):
                     option=self.symbol,
                     minutes=self._trade_minutes,
                     account_ccy=account_ccy,
+                    trade_type=self._trade_type,
                 )
                 if pct is None:
                     self._status("ожидание процента")

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -238,6 +238,7 @@ class FixedStakeStrategy(StrategyBase):
                     option=self.symbol,
                     minutes=self._trade_minutes,
                     account_ccy=account_ccy,
+                    trade_type=self._trade_type,
                 )
             except Exception:
                 pct = None
@@ -448,7 +449,8 @@ class FixedStakeStrategy(StrategyBase):
         self._last_signal_ver = ver
         self._last_indicator = (meta or {}).get("indicator") or "-"
 
-        self._next_expire_dt = (meta or {}).get("next_timestamp")
+        ts = (meta or {}).get("next_timestamp")
+        self._next_expire_dt = ts.astimezone().replace(tzinfo=None) if ts else None
 
         sig_symbol = (meta or {}).get("symbol") or self.symbol
         sig_tf = (meta or {}).get("timeframe") or self.timeframe

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -266,6 +266,7 @@ class MartingaleStrategy(StrategyBase):
                     option=self.symbol,
                     minutes=self._trade_minutes,
                     account_ccy=account_ccy,
+                    trade_type=self._trade_type,
                 )
                 if pct is None:
                     self._status("ожидание процента")
@@ -525,7 +526,8 @@ class MartingaleStrategy(StrategyBase):
         self._last_signal_ver = ver
         self._last_indicator = (meta or {}).get("indicator") or "-"
 
-        self._next_expire_dt = (meta or {}).get("next_timestamp")
+        ts = (meta or {}).get("next_timestamp")
+        self._next_expire_dt = ts.astimezone().replace(tzinfo=None) if ts else None
 
         sig_symbol = (meta or {}).get("symbol") or self.symbol
         sig_tf = (meta or {}).get("timeframe") or self.timeframe

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -278,6 +278,7 @@ class OscarGrind2Strategy(StrategyBase):
                     option=self.symbol,
                     minutes=self._trade_minutes,
                     account_ccy=account_ccy,
+                    trade_type=self._trade_type,
                 )
                 if pct is None:
                     self._status("ожидание процента")
@@ -592,7 +593,8 @@ class OscarGrind2Strategy(StrategyBase):
         self._last_signal_ver = ver
         self._last_indicator = (meta or {}).get("indicator") or "-"
 
-        self._next_expire_dt = (meta or {}).get("next_timestamp")
+        ts = (meta or {}).get("next_timestamp")
+        self._next_expire_dt = ts.astimezone().replace(tzinfo=None) if ts else None
 
         sig_symbol = (meta or {}).get("symbol") or self.symbol
         sig_tf = (meta or {}).get("timeframe") or self.timeframe


### PR DESCRIPTION
## Summary
- support Classic trades in `get_current_percent` by sending `type=Classic` and omitting `time`
- pass trade type to strategies and localize expiration timestamps for Classic orders

## Testing
- `python -m py_compile core/intrade_api.py core/intrade_api_async.py strategies/antimartin.py strategies/fibonacci.py strategies/fixed.py strategies/martingale.py strategies/oscar_grind_2.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b05dc0b8b88322a32db0b189279246