### PR TITLE
Respect strategy minutes for sprint mode

### DIFF
--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -133,6 +133,7 @@ class StrategyControlDialog(QDialog):
 
         strategy_key = str(self.bot.strategy_kwargs.get("strategy_key", "")).lower()
         self.strategy_key = strategy_key
+        self.minutes = None
 
         if strategy_key in ("oscar_grind_1", "oscar_grind_2"):
             self.minutes = QSpinBox()
@@ -241,6 +242,13 @@ class StrategyControlDialog(QDialog):
             form.addRow("Мин. баланс", self.min_balance)
             form.addRow("Коэффициент", self.coefficient)
             form.addRow("Мин. процент", self.min_percent)
+
+        def _update_minutes_enabled(text: str):
+            if self.minutes is not None:
+                self.minutes.setEnabled(text != "classic")
+
+        self.trade_type.currentTextChanged.connect(_update_minutes_enabled)
+        _update_minutes_enabled(self.trade_type.currentText())
 
         # Кнопка «Сохранить настройки»
         settings_row = QWidget()
@@ -386,21 +394,23 @@ class StrategyControlDialog(QDialog):
     # ---- сохранение настроек ----
     def save_settings(self):
         symbol = str(self.bot.strategy_kwargs.get("symbol", ""))
+        trade_type = self.trade_type.currentText()
         m = int(self.minutes.value())
-        norm = normalize_sprint(symbol, m)
-
-        if norm is None:
-            box = QMessageBox(self)
-            box.setIcon(QMessageBox.Icon.Warning)
-            box.setWindowTitle("Недопустимое время экспирации")
-            if symbol == "BTCUSDT":
-                box.setText("Для BTCUSDT время должно быть от 5 до 500 минут.")
-            else:
-                box.setText(
-                    "Для выбранной пары разрешено 1 или 3–500 минут (2 минуты — нельзя)."
-                )
-            box.open()
-            return
+        norm = m
+        if trade_type != "classic":
+            norm = normalize_sprint(symbol, m)
+            if norm is None:
+                box = QMessageBox(self)
+                box.setIcon(QMessageBox.Icon.Warning)
+                box.setWindowTitle("Недопустимое время экспирации")
+                if symbol == "BTCUSDT":
+                    box.setText("Для BTCUSDT время должно быть от 5 до 500 минут.")
+                else:
+                    box.setText(
+                        "Для выбранной пары разрешено 1 или 3–500 минут (2 минуты — нельзя)."
+                    )
+                box.open()
+                return
 
         if getattr(self, "strategy_key", "") in ("oscar_grind_1", "oscar_grind_2"):
             new_params = {
@@ -411,16 +421,18 @@ class StrategyControlDialog(QDialog):
                 "min_balance": self.min_balance.value(),
                 "min_percent": self.min_percent.value(),
                 "lock_direction_to_first": bool(self.lock_direction.value() == 1),
-                "minutes": int(norm),
             }
+            if trade_type != "classic":
+                new_params["minutes"] = int(norm)
         elif getattr(self, "strategy_key", "") == "fixed":
             new_params = {
                 "base_investment": self.base_investment.value(),
                 "repeat_count": self.repeat_count.value(),
                 "min_balance": self.min_balance.value(),
                 "min_percent": self.min_percent.value(),
-                "minutes": int(norm),
             }
+            if trade_type != "classic":
+                new_params["minutes"] = int(norm)
         else:
             new_params = {
                 "base_investment": self.base_investment.value(),
@@ -429,15 +441,17 @@ class StrategyControlDialog(QDialog):
                 "min_balance": self.min_balance.value(),
                 "coefficient": round(float(self.coefficient.value()), 2),
                 "min_percent": self.min_percent.value(),
-                "minutes": int(norm),
             }
-        new_params["trade_type"] = self.trade_type.currentText()
+            if trade_type != "classic":
+                new_params["minutes"] = int(norm)
+        new_params["trade_type"] = trade_type
 
         self.bot.strategy_kwargs.setdefault("params", {}).update(new_params)
         if self.bot.strategy and hasattr(self.bot.strategy, "update_params"):
             self.bot.strategy.update_params(**new_params)
 
-        self.minutes.setValue(int(norm))
+        if trade_type != "classic":
+            self.minutes.setValue(int(norm))
 
         formatted = []
         for k, v in new_params.items():

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -545,18 +545,6 @@ class AntiMartingaleStrategy(StrategyBase):
         if self._use_any_timeframe:
             self.timeframe = sig_tf
             self.params["timeframe"] = self.timeframe
-        if self._use_any_symbol or self._use_any_timeframe:
-            raw_minutes = _minutes_from_timeframe(self.timeframe)
-            norm = normalize_sprint(self.symbol, raw_minutes)
-            if norm is None:
-                fallback = raw_minutes
-                norm = normalize_sprint(self.symbol, fallback) or fallback
-                if self.log:
-                    self.log(
-                        f"[{self.symbol}] ⚠ Минуты {raw_minutes} недопустимы. Использую {norm}."
-                    )
-            self._trade_minutes = int(norm)
-            self.params["minutes"] = self._trade_minutes
 
         from datetime import datetime
 
@@ -590,8 +578,6 @@ class AntiMartingaleStrategy(StrategyBase):
             self._use_any_timeframe = tf_raw in (ALL_TF_LABEL, "*")
             self.timeframe = "*" if self._use_any_timeframe else tf
             self.params["timeframe"] = self.timeframe
-            if self.timeframe != "*" and "minutes" not in params:
-                self._trade_minutes = _minutes_from_timeframe(self.timeframe)
 
         if "account_currency" in params:
             want = str(params["account_currency"]).upper()

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -476,18 +476,6 @@ class FixedStakeStrategy(StrategyBase):
         if self._use_any_timeframe:
             self.timeframe = sig_tf
             self.params["timeframe"] = self.timeframe
-        if self._use_any_symbol or self._use_any_timeframe:
-            raw_minutes = _minutes_from_timeframe(self.timeframe)
-            norm = normalize_sprint(self.symbol, raw_minutes)
-            if norm is None:
-                fallback = raw_minutes
-                norm = normalize_sprint(self.symbol, fallback) or fallback
-                if self.log:
-                    self.log(
-                        f"[{self.symbol}] ⚠ Минуты {raw_minutes} недопустимы. Использую {norm}."
-                    )
-            self._trade_minutes = int(norm)
-            self.params["minutes"] = self._trade_minutes
 
         from datetime import datetime
 
@@ -521,8 +509,6 @@ class FixedStakeStrategy(StrategyBase):
             self._use_any_timeframe = tf_raw in (ALL_TF_LABEL, "*")
             self.timeframe = "*" if self._use_any_timeframe else tf
             self.params["timeframe"] = self.timeframe
-            if self.timeframe != "*" and "minutes" not in params:
-                self._trade_minutes = _minutes_from_timeframe(self.timeframe)
 
         if "account_currency" in params:
             want = str(params["account_currency"]).upper()

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -551,18 +551,6 @@ class MartingaleStrategy(StrategyBase):
         if self._use_any_timeframe:
             self.timeframe = sig_tf
             self.params["timeframe"] = self.timeframe
-        if self._use_any_symbol or self._use_any_timeframe:
-            raw_minutes = _minutes_from_timeframe(self.timeframe)
-            norm = normalize_sprint(self.symbol, raw_minutes)
-            if norm is None:
-                fallback = raw_minutes
-                norm = normalize_sprint(self.symbol, fallback) or fallback
-                if self.log:
-                    self.log(
-                        f"[{self.symbol}] ⚠ Минуты {raw_minutes} недопустимы. Использую {norm}."
-                    )
-            self._trade_minutes = int(norm)
-            self.params["minutes"] = self._trade_minutes
 
         from datetime import datetime
 
@@ -596,8 +584,6 @@ class MartingaleStrategy(StrategyBase):
             self._use_any_timeframe = tf_raw in (ALL_TF_LABEL, "*")
             self.timeframe = "*" if self._use_any_timeframe else tf
             self.params["timeframe"] = self.timeframe
-            if self.timeframe != "*" and "minutes" not in params:
-                self._trade_minutes = _minutes_from_timeframe(self.timeframe)
 
         if "account_currency" in params:
             want = str(params["account_currency"]).upper()

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -618,18 +618,6 @@ class OscarGrind2Strategy(StrategyBase):
         if self._use_any_timeframe:
             self.timeframe = sig_tf
             self.params["timeframe"] = self.timeframe
-        if self._use_any_symbol or self._use_any_timeframe:
-            raw_minutes = _minutes_from_timeframe(self.timeframe)
-            norm = normalize_sprint(self.symbol, raw_minutes)
-            if norm is None:
-                fallback = raw_minutes
-                norm = normalize_sprint(self.symbol, fallback) or fallback
-                if self.log:
-                    self.log(
-                        f"[{self.symbol}] ⚠ Минуты {raw_minutes} недопустимы. Использую {norm}."
-                    )
-            self._trade_minutes = int(norm)
-            self.params["minutes"] = self._trade_minutes
 
         from datetime import datetime
 
@@ -663,8 +651,6 @@ class OscarGrind2Strategy(StrategyBase):
             self._use_any_timeframe = tf_raw in (ALL_TF_LABEL, "*")
             self.timeframe = "*" if self._use_any_timeframe else tf
             self.params["timeframe"] = self.timeframe
-            if self.timeframe != "*" and "minutes" not in params:
-                self._trade_minutes = _minutes_from_timeframe(self.timeframe)
 
         if "account_currency" in params:
             want = str(params["account_currency"]).upper()


### PR DESCRIPTION
## Summary
- Preserve user-specified expiry minutes for sprint trades across all strategies
- Disable trade duration control in Strategy dialog when classic mode is selected
- Save minutes only for sprint mode in Strategy dialog settings

## Testing
- `python -m py_compile gui/strategy_control_dialog.py strategies/antimartin.py strategies/fixed.py strategies/martingale.py strategies/oscar_grind_2.py`


------
https://chatgpt.com/codex/tasks/task_e_68b13145a55c8322818ae1a2a2d9fc15