### PR TITLE
Use strategy-defined duration for trade timers

### DIFF
--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -227,9 +227,6 @@ class AntiMartingaleStrategy(StrategyBase):
             wait_low = float(
                 self.params.get("wait_on_low_percent", DEFAULTS["wait_on_low_percent"])
             )
-            result_wait_s = float(
-                self.params.get("result_wait_s", DEFAULTS["result_wait_s"])
-            )
             sig_timeout = float(
                 self.params.get("signal_timeout_sec", DEFAULTS["signal_timeout_sec"])
             )
@@ -387,6 +384,24 @@ class AntiMartingaleStrategy(StrategyBase):
 
                 did_place_any_trade = True
 
+                # определяем длительность сделки (для таймера и ожидания результата)
+                wait_seconds = self.params.get("result_wait_s")
+                if wait_seconds is None:
+                    from datetime import datetime
+
+                    if (
+                        self._trade_type == "classic"
+                        and self._next_expire_dt is not None
+                    ):
+                        wait_seconds = max(
+                            0.0,
+                            (self._next_expire_dt - datetime.now()).total_seconds(),
+                        )
+                    else:
+                        wait_seconds = float(self._trade_minutes) * 60.0
+                else:
+                    wait_seconds = float(wait_seconds)
+
                 if callable(self._on_trade_pending):
                     from datetime import datetime
 
@@ -401,7 +416,7 @@ class AntiMartingaleStrategy(StrategyBase):
                             direction=status,
                             stake=float(stake),
                             percent=int(pct),
-                            wait_seconds=float(result_wait_s),
+                            wait_seconds=float(wait_seconds),
                             account_mode=account_mode,
                             indicator=self._last_indicator,
                         )
@@ -415,7 +430,7 @@ class AntiMartingaleStrategy(StrategyBase):
                     user_id=self.user_id,
                     user_hash=self.user_hash,
                     trade_id=trade_id,
-                    wait_time=result_wait_s,
+                    wait_time=wait_seconds,
                 )
 
                 if callable(self._on_trade_result):

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -157,9 +157,6 @@ class FibonacciStrategy(MartingaleStrategy):
                     "wait_on_low_percent", DEFAULTS["wait_on_low_percent"]
                 )
             )
-            result_wait_s = float(
-                self.params.get("result_wait_s", DEFAULTS["result_wait_s"])
-            )
             sig_timeout = float(
                 self.params.get("signal_timeout_sec", DEFAULTS["signal_timeout_sec"])
             )
@@ -316,10 +313,28 @@ class FibonacciStrategy(MartingaleStrategy):
 
                 did_place_any_trade = True
 
+                # определяем длительность сделки (для таймера и ожидания результата)
+                wait_seconds = self.params.get("result_wait_s")
+                if wait_seconds is None:
+                    from datetime import datetime
+
+                    if (
+                        self._trade_type == "classic"
+                        and self._next_expire_dt is not None
+                    ):
+                        wait_seconds = max(
+                            0.0,
+                            (self._next_expire_dt - datetime.now()).total_seconds(),
+                        )
+                    else:
+                        wait_seconds = float(self._trade_minutes) * 60.0
+                else:
+                    wait_seconds = float(wait_seconds)
+
                 if callable(self._on_trade_pending):
                     from datetime import datetime
 
-                    placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+                    placed_at_str = datetime.now().strftime("%d.%м.%Y %H:%M:%S")
                     try:
                         self._on_trade_pending(
                             trade_id=trade_id,
@@ -330,7 +345,7 @@ class FibonacciStrategy(MartingaleStrategy):
                             direction=status,
                             stake=float(stake),
                             percent=int(pct),
-                            wait_seconds=float(result_wait_s),
+                            wait_seconds=float(wait_seconds),
                             account_mode=account_mode,
                             indicator=self._last_indicator,
                         )
@@ -344,7 +359,7 @@ class FibonacciStrategy(MartingaleStrategy):
                     user_id=self.user_id,
                     user_hash=self.user_hash,
                     trade_id=trade_id,
-                    wait_time=result_wait_s,
+                    wait_time=wait_seconds,
                 )
 
                 if callable(self._on_trade_result):

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -223,9 +223,6 @@ class FixedStakeStrategy(StrategyBase):
             wait_low = float(
                 self.params.get("wait_on_low_percent", DEFAULTS["wait_on_low_percent"])
             )
-            result_wait_s = float(
-                self.params.get("result_wait_s", DEFAULTS["result_wait_s"])
-            )
             sig_timeout = float(
                 self.params.get("signal_timeout_sec", DEFAULTS["signal_timeout_sec"])
             )
@@ -374,6 +371,21 @@ class FixedStakeStrategy(StrategyBase):
 
             trades_left -= 1
 
+            # определяем длительность сделки (для таймера и ожидания результата)
+            wait_seconds = self.params.get("result_wait_s")
+            if wait_seconds is None:
+                from datetime import datetime
+
+                if self._trade_type == "classic" and self._next_expire_dt is not None:
+                    wait_seconds = max(
+                        0.0,
+                        (self._next_expire_dt - datetime.now()).total_seconds(),
+                    )
+                else:
+                    wait_seconds = float(self._trade_minutes) * 60.0
+            else:
+                wait_seconds = float(wait_seconds)
+
             if callable(self._on_trade_pending):
                 from datetime import datetime
 
@@ -388,7 +400,7 @@ class FixedStakeStrategy(StrategyBase):
                         direction=status,
                         stake=float(stake),
                         percent=int(pct),
-                        wait_seconds=float(result_wait_s),
+                        wait_seconds=float(wait_seconds),
                         account_mode=account_mode,
                         indicator=self._last_indicator,
                     )
@@ -402,7 +414,7 @@ class FixedStakeStrategy(StrategyBase):
                 user_id=self.user_id,
                 user_hash=self.user_hash,
                 trade_id=trade_id,
-                wait_time=result_wait_s,
+                wait_time=wait_seconds,
             )
 
             if callable(self._on_trade_result):

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -232,9 +232,6 @@ class MartingaleStrategy(StrategyBase):
             wait_low = float(
                 self.params.get("wait_on_low_percent", DEFAULTS["wait_on_low_percent"])
             )
-            result_wait_s = float(
-                self.params.get("result_wait_s", DEFAULTS["result_wait_s"])
-            )
             sig_timeout = float(
                 self.params.get("signal_timeout_sec", DEFAULTS["signal_timeout_sec"])
             )
@@ -392,6 +389,24 @@ class MartingaleStrategy(StrategyBase):
 
                 did_place_any_trade = True
 
+                # определяем длительность сделки (для таймера и ожидания результата)
+                wait_seconds = self.params.get("result_wait_s")
+                if wait_seconds is None:
+                    from datetime import datetime
+
+                    if (
+                        self._trade_type == "classic"
+                        and self._next_expire_dt is not None
+                    ):
+                        wait_seconds = max(
+                            0.0,
+                            (self._next_expire_dt - datetime.now()).total_seconds(),
+                        )
+                    else:
+                        wait_seconds = float(self._trade_minutes) * 60.0
+                else:
+                    wait_seconds = float(wait_seconds)
+
                 # GUI: ожидание результата (с двумя временами)
                 if callable(self._on_trade_pending):
                     from datetime import datetime
@@ -407,7 +422,7 @@ class MartingaleStrategy(StrategyBase):
                             direction=status,
                             stake=float(stake),
                             percent=int(pct),
-                            wait_seconds=float(result_wait_s),
+                            wait_seconds=float(wait_seconds),
                             account_mode=account_mode,
                             indicator=self._last_indicator,
                         )
@@ -421,7 +436,7 @@ class MartingaleStrategy(StrategyBase):
                     user_id=self.user_id,
                     user_hash=self.user_hash,
                     trade_id=trade_id,
-                    wait_time=result_wait_s,
+                    wait_time=wait_seconds,
                 )
 
                 if callable(self._on_trade_result):

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -233,9 +233,6 @@ class OscarGrind2Strategy(StrategyBase):
             wait_low = float(
                 self.params.get("wait_on_low_percent", DEFAULTS["wait_on_low_percent"])
             )
-            result_wait_s = float(
-                self.params.get("result_wait_s", DEFAULTS["result_wait_s"])
-            )
             sig_timeout = float(
                 self.params.get("signal_timeout_sec", DEFAULTS["signal_timeout_sec"])
             )
@@ -402,11 +399,29 @@ class OscarGrind2Strategy(StrategyBase):
                     await self.sleep(1.0)
                     continue
 
+                # определяем длительность сделки (для таймера и ожидания результата)
+                wait_seconds = self.params.get("result_wait_s")
+                if wait_seconds is None:
+                    from datetime import datetime
+
+                    if (
+                        self._trade_type == "classic"
+                        and self._next_expire_dt is not None
+                    ):
+                        wait_seconds = max(
+                            0.0,
+                            (self._next_expire_dt - datetime.now()).total_seconds(),
+                        )
+                    else:
+                        wait_seconds = float(self._trade_minutes) * 60.0
+                else:
+                    wait_seconds = float(wait_seconds)
+
                 # GUI: ожидаем результат (две метки времени)
                 if callable(self._on_trade_pending):
                     from datetime import datetime
 
-                    placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+                    placed_at_str = datetime.now().strftime("%d.%м.%Y %H:%M:%S")
                     try:
                         self._on_trade_pending(
                             trade_id=trade_id,
@@ -417,7 +432,7 @@ class OscarGrind2Strategy(StrategyBase):
                             direction=status,
                             stake=float(stake),
                             percent=int(pct),
-                            wait_seconds=float(result_wait_s),
+                            wait_seconds=float(wait_seconds),
                             account_mode=account_mode,
                             indicator=self._last_indicator,
                         )
@@ -431,7 +446,7 @@ class OscarGrind2Strategy(StrategyBase):
                     user_id=self.user_id,
                     user_hash=self.user_hash,
                     trade_id=trade_id,
-                    wait_time=result_wait_s,
+                    wait_time=wait_seconds,
                 )
 
                 # GUI: результат


### PR DESCRIPTION
## Summary
- derive pending trade timer from strategy's configured duration or classic expiry
- pass computed wait_seconds to result polling

## Testing
- `python -m py_compile strategies/martingale.py strategies/oscar_grind_2.py strategies/fixed.py strategies/antimartin.py strategies/fibonacci.py`


------
https://chatgpt.com/codex/tasks/task_e_68b168f4aa4c8322b6cce3dd4a8a2ae1