### PR TITLE
fix: correct trade timer duration

### DIFF
--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -385,26 +385,27 @@ class AntiMartingaleStrategy(StrategyBase):
                 did_place_any_trade = True
 
                 # определяем длительность сделки (для таймера и ожидания результата)
+                from datetime import datetime
+
+                if (
+                    self._trade_type == "classic"
+                    and self._next_expire_dt is not None
+                ):
+                    trade_seconds = max(
+                        0.0, (self._next_expire_dt - datetime.now()).total_seconds()
+                    )
+                    expected_end_ts = self._next_expire_dt.timestamp()
+                else:
+                    trade_seconds = float(self._trade_minutes) * 60.0
+                    expected_end_ts = datetime.now().timestamp() + trade_seconds
+
                 wait_seconds = self.params.get("result_wait_s")
                 if wait_seconds is None:
-                    from datetime import datetime
-
-                    if (
-                        self._trade_type == "classic"
-                        and self._next_expire_dt is not None
-                    ):
-                        wait_seconds = max(
-                            0.0,
-                            (self._next_expire_dt - datetime.now()).total_seconds(),
-                        )
-                    else:
-                        wait_seconds = float(self._trade_minutes) * 60.0
+                    wait_seconds = trade_seconds
                 else:
                     wait_seconds = float(wait_seconds)
 
                 if callable(self._on_trade_pending):
-                    from datetime import datetime
-
                     placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
                     try:
                         self._on_trade_pending(
@@ -416,9 +417,10 @@ class AntiMartingaleStrategy(StrategyBase):
                             direction=status,
                             stake=float(stake),
                             percent=int(pct),
-                            wait_seconds=float(wait_seconds),
+                            wait_seconds=float(trade_seconds),
                             account_mode=account_mode,
                             indicator=self._last_indicator,
+                            expected_end_ts=expected_end_ts,
                         )
                     except Exception:
                         pass

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -314,26 +314,27 @@ class FibonacciStrategy(MartingaleStrategy):
                 did_place_any_trade = True
 
                 # определяем длительность сделки (для таймера и ожидания результата)
+                from datetime import datetime
+
+                if (
+                    self._trade_type == "classic"
+                    and self._next_expire_dt is not None
+                ):
+                    trade_seconds = max(
+                        0.0, (self._next_expire_dt - datetime.now()).total_seconds()
+                    )
+                    expected_end_ts = self._next_expire_dt.timestamp()
+                else:
+                    trade_seconds = float(self._trade_minutes) * 60.0
+                    expected_end_ts = datetime.now().timestamp() + trade_seconds
+
                 wait_seconds = self.params.get("result_wait_s")
                 if wait_seconds is None:
-                    from datetime import datetime
-
-                    if (
-                        self._trade_type == "classic"
-                        and self._next_expire_dt is not None
-                    ):
-                        wait_seconds = max(
-                            0.0,
-                            (self._next_expire_dt - datetime.now()).total_seconds(),
-                        )
-                    else:
-                        wait_seconds = float(self._trade_minutes) * 60.0
+                    wait_seconds = trade_seconds
                 else:
                     wait_seconds = float(wait_seconds)
 
                 if callable(self._on_trade_pending):
-                    from datetime import datetime
-
                     placed_at_str = datetime.now().strftime("%d.%м.%Y %H:%M:%S")
                     try:
                         self._on_trade_pending(
@@ -345,9 +346,10 @@ class FibonacciStrategy(MartingaleStrategy):
                             direction=status,
                             stake=float(stake),
                             percent=int(pct),
-                            wait_seconds=float(wait_seconds),
+                            wait_seconds=float(trade_seconds),
                             account_mode=account_mode,
                             indicator=self._last_indicator,
+                            expected_end_ts=expected_end_ts,
                         )
                     except Exception:
                         pass

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -372,17 +372,20 @@ class FixedStakeStrategy(StrategyBase):
             trades_left -= 1
 
             # определяем длительность сделки (для таймера и ожидания результата)
+            from datetime import datetime
+
+            if self._trade_type == "classic" and self._next_expire_dt is not None:
+                trade_seconds = max(
+                    0.0, (self._next_expire_dt - datetime.now()).total_seconds()
+                )
+                expected_end_ts = self._next_expire_dt.timestamp()
+            else:
+                trade_seconds = float(self._trade_minutes) * 60.0
+                expected_end_ts = datetime.now().timestamp() + trade_seconds
+
             wait_seconds = self.params.get("result_wait_s")
             if wait_seconds is None:
-                from datetime import datetime
-
-                if self._trade_type == "classic" and self._next_expire_dt is not None:
-                    wait_seconds = max(
-                        0.0,
-                        (self._next_expire_dt - datetime.now()).total_seconds(),
-                    )
-                else:
-                    wait_seconds = float(self._trade_minutes) * 60.0
+                wait_seconds = trade_seconds
             else:
                 wait_seconds = float(wait_seconds)
 
@@ -400,9 +403,10 @@ class FixedStakeStrategy(StrategyBase):
                         direction=status,
                         stake=float(stake),
                         percent=int(pct),
-                        wait_seconds=float(wait_seconds),
+                        wait_seconds=float(trade_seconds),
                         account_mode=account_mode,
                         indicator=self._last_indicator,
+                        expected_end_ts=expected_end_ts,
                     )
                 except Exception:
                     pass

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -390,27 +390,28 @@ class MartingaleStrategy(StrategyBase):
                 did_place_any_trade = True
 
                 # определяем длительность сделки (для таймера и ожидания результата)
+                from datetime import datetime
+
+                if (
+                    self._trade_type == "classic"
+                    and self._next_expire_dt is not None
+                ):
+                    trade_seconds = max(
+                        0.0, (self._next_expire_dt - datetime.now()).total_seconds()
+                    )
+                    expected_end_ts = self._next_expire_dt.timestamp()
+                else:
+                    trade_seconds = float(self._trade_minutes) * 60.0
+                    expected_end_ts = datetime.now().timestamp() + trade_seconds
+
                 wait_seconds = self.params.get("result_wait_s")
                 if wait_seconds is None:
-                    from datetime import datetime
-
-                    if (
-                        self._trade_type == "classic"
-                        and self._next_expire_dt is not None
-                    ):
-                        wait_seconds = max(
-                            0.0,
-                            (self._next_expire_dt - datetime.now()).total_seconds(),
-                        )
-                    else:
-                        wait_seconds = float(self._trade_minutes) * 60.0
+                    wait_seconds = trade_seconds
                 else:
                     wait_seconds = float(wait_seconds)
 
                 # GUI: ожидание результата (с двумя временами)
                 if callable(self._on_trade_pending):
-                    from datetime import datetime
-
                     placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
                     try:
                         self._on_trade_pending(
@@ -422,9 +423,10 @@ class MartingaleStrategy(StrategyBase):
                             direction=status,
                             stake=float(stake),
                             percent=int(pct),
-                            wait_seconds=float(wait_seconds),
+                            wait_seconds=float(trade_seconds),
                             account_mode=account_mode,
                             indicator=self._last_indicator,
+                            expected_end_ts=expected_end_ts,
                         )
                     except Exception:
                         pass

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -400,27 +400,28 @@ class OscarGrind2Strategy(StrategyBase):
                     continue
 
                 # определяем длительность сделки (для таймера и ожидания результата)
+                from datetime import datetime
+
+                if (
+                    self._trade_type == "classic"
+                    and self._next_expire_dt is not None
+                ):
+                    trade_seconds = max(
+                        0.0, (self._next_expire_dt - datetime.now()).total_seconds()
+                    )
+                    expected_end_ts = self._next_expire_dt.timestamp()
+                else:
+                    trade_seconds = float(self._trade_minutes) * 60.0
+                    expected_end_ts = datetime.now().timestamp() + trade_seconds
+
                 wait_seconds = self.params.get("result_wait_s")
                 if wait_seconds is None:
-                    from datetime import datetime
-
-                    if (
-                        self._trade_type == "classic"
-                        and self._next_expire_dt is not None
-                    ):
-                        wait_seconds = max(
-                            0.0,
-                            (self._next_expire_dt - datetime.now()).total_seconds(),
-                        )
-                    else:
-                        wait_seconds = float(self._trade_minutes) * 60.0
+                    wait_seconds = trade_seconds
                 else:
                     wait_seconds = float(wait_seconds)
 
                 # GUI: ожидаем результат (две метки времени)
                 if callable(self._on_trade_pending):
-                    from datetime import datetime
-
                     placed_at_str = datetime.now().strftime("%d.%м.%Y %H:%M:%S")
                     try:
                         self._on_trade_pending(
@@ -432,9 +433,10 @@ class OscarGrind2Strategy(StrategyBase):
                             direction=status,
                             stake=float(stake),
                             percent=int(pct),
-                            wait_seconds=float(wait_seconds),
+                            wait_seconds=float(trade_seconds),
                             account_mode=account_mode,
                             indicator=self._last_indicator,
+                            expected_end_ts=expected_end_ts,
                         )
                     except Exception:
                         pass


### PR DESCRIPTION
## Summary
- calculate trade duration and pass expected end timestamp to pending-trade callbacks
- show actual countdown in trade tables instead of fixed 60 seconds

## Testing
- `python -m py_compile strategies/fixed.py`
- `python -m py_compile strategies/antimartin.py`
- `python -m py_compile strategies/fibonacci.py`
- `python -m py_compile strategies/martingale.py`
- `python -m py_compile strategies/oscar_grind_2.py`


------
https://chatgpt.com/codex/tasks/task_e_68b16b4fd388832290d5499967e7fab8