### PR TITLE
Fix main trades table updates and show currency symbols

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -691,6 +691,7 @@ class MainWindow(QWidget):
             percent=int(percent),
             account_mode=acc,
             expected_end_ts=expected_end_ts,
+            currency=self.account_currency,
         )
 
     def add_trade_result(
@@ -728,6 +729,7 @@ class MainWindow(QWidget):
                 duration=0.0,
                 percent=int(percent),
                 account_mode=acc,
+                currency=self.account_currency,
             )
 
         self.trades_table.set_result(tid or "-", profit, self.account_currency)
@@ -872,32 +874,32 @@ class MainWindow(QWidget):
         """
         from time import time as _now
 
-        wait_seconds = float(kw.get("wait_seconds", 0.0))
-        expected_end_ts = kw.get("expected_end_ts")
+        payload = dict(kw)
+        wait_seconds = float(payload.get("wait_seconds", 0.0))
+        expected_end_ts = payload.get("expected_end_ts")
         if expected_end_ts is None:
             expected_end_ts = _now() + wait_seconds
+        payload["expected_end_ts"] = float(expected_end_ts)
 
+        # В общую (главную) таблицу добавляем колонку "Стратегия"
+        key = bot.strategy_kwargs.get("strategy_key", "")
+        payload_main = dict(payload)
+        payload_main["strategy"] = self.strategy_label(key)
         try:
-            # В общую (главную) таблицу
-            key = bot.strategy_kwargs.get("strategy_key", "")
-            strat_label = self.strategy_label(key)
-            self.add_trade_pending(
-                **kw, expected_end_ts=expected_end_ts, strategy=strat_label
-            )
-        finally:
-            # Готовим полезную нагрузку с абсолютным дедлайном
-            payload = dict(kw)
-            payload["expected_end_ts"] = float(expected_end_ts)
+            self.add_trade_pending(**payload_main)
+        except Exception:
+            pass
 
-            # ⬇️ НОВОЕ: сохраняем в историю, чтобы StrategyControlDialog восстановил «ожидание»
-            self.bot_trade_history[bot].append(("pending", dict(payload)))
+        # Для окон стратегии и истории колонка "Стратегия" не нужна
+        payload_local = dict(payload)
+        self.bot_trade_history[bot].append(("pending", dict(payload_local)))
 
-            # Уведомляем открытые окна конкретного бота
-            for cb in list(self.bot_trade_listeners.get(bot, [])):
-                try:
-                    cb("pending", payload)
-                except Exception:
-                    pass
+        # Уведомляем открытые окна конкретного бота
+        for cb in list(self.bot_trade_listeners.get(bot, [])):
+            try:
+                cb("pending", dict(payload_local))
+            except Exception:
+                pass
 
     def on_bot_finished(self, bot):
         # Просто помечаем статус, оставляя строку в таблице — бот можно перезапустить

--- a/gui/trades_table_widget.py
+++ b/gui/trades_table_widget.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from PyQt6.QtWidgets import QTableWidget, QTableWidgetItem, QHeaderView
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QColor, QBrush
-from core.money import format_amount
+from core.money import format_amount, format_money
 
 
 class TradesTableWidget(QTableWidget):
@@ -72,6 +72,7 @@ class TradesTableWidget(QTableWidget):
         indicator: str = "-",  # НАЗВАНИЕ ИНДИКАТОРА
         strategy: str = "-",
         expected_end_ts: float | None = None,
+        currency: str | None = None,
     ):
         """Добавляет строку ожидания с таймером."""
         from time import time as _now
@@ -94,6 +95,11 @@ class TradesTableWidget(QTableWidget):
 
         dir_text = "ВВЕРХ" if int(direction) == 1 else "ВНИЗ"
         left_now = max(0.0, expected_end_ts - _now())
+        if currency:
+            stake_txt = format_money(stake, currency)
+        else:
+            stake_txt = format_amount(stake)
+
         values = [
             signal_at,
             placed_at,
@@ -102,7 +108,7 @@ class TradesTableWidget(QTableWidget):
             symbol,
             timeframe,
             dir_text,
-            format_amount(stake),
+            stake_txt,
             f"{int(round(duration / 60))} мин",
             f"{percent}%",
             f"Ожидание ({_fmt_left(left_now)})",
@@ -158,7 +164,7 @@ class TradesTableWidget(QTableWidget):
         }
 
     def set_result(
-        self, trade_id: str, profit: float | None, currency_suffix: str = "",
+        self, trade_id: str, profit: float | None, currency: str = "",
     ):
         info = self._pending_rows.pop(trade_id, None)
         if info:
@@ -183,9 +189,10 @@ class TradesTableWidget(QTableWidget):
             pl_item.setText("неизв.")
             return
 
-        text = format_amount(profit, show_plus=True)
-        if currency_suffix:
-            text += f" {currency_suffix}"
+        if currency:
+            text = format_money(profit, currency, show_plus=True)
+        else:
+            text = format_amount(profit, show_plus=True)
         pl_item.setText(text)
 
         # лёгкая подсветка всей строки

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -405,8 +405,8 @@ class AntiMartingaleStrategy(StrategyBase):
                 else:
                     wait_seconds = float(wait_seconds)
 
+                placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
                 if callable(self._on_trade_pending):
-                    placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
                     try:
                         self._on_trade_pending(
                             trade_id=trade_id,
@@ -436,9 +436,6 @@ class AntiMartingaleStrategy(StrategyBase):
                 )
 
                 if callable(self._on_trade_result):
-                    from datetime import datetime
-
-                    placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
                     try:
                         self._on_trade_result(
                             trade_id=trade_id,

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -334,8 +334,8 @@ class FibonacciStrategy(MartingaleStrategy):
                 else:
                     wait_seconds = float(wait_seconds)
 
+                placed_at_str = datetime.now().strftime("%d.%м.%Y %H:%M:%S")
                 if callable(self._on_trade_pending):
-                    placed_at_str = datetime.now().strftime("%d.%м.%Y %H:%M:%S")
                     try:
                         self._on_trade_pending(
                             trade_id=trade_id,
@@ -365,9 +365,6 @@ class FibonacciStrategy(MartingaleStrategy):
                 )
 
                 if callable(self._on_trade_result):
-                    from datetime import datetime
-
-                    placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%М:%S")
                     try:
                         self._on_trade_result(
                             trade_id=trade_id,

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -389,10 +389,8 @@ class FixedStakeStrategy(StrategyBase):
             else:
                 wait_seconds = float(wait_seconds)
 
+            placed_at_str = datetime.now().strftime("%d.%м.%Y %H:%M:%S")
             if callable(self._on_trade_pending):
-                from datetime import datetime
-
-                placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
                 try:
                     self._on_trade_pending(
                         trade_id=trade_id,
@@ -422,9 +420,6 @@ class FixedStakeStrategy(StrategyBase):
             )
 
             if callable(self._on_trade_result):
-                from datetime import datetime
-
-                placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
                 try:
                     self._on_trade_result(
                         trade_id=trade_id,

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -411,8 +411,8 @@ class MartingaleStrategy(StrategyBase):
                     wait_seconds = float(wait_seconds)
 
                 # GUI: ожидание результата (с двумя временами)
+                placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
                 if callable(self._on_trade_pending):
-                    placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
                     try:
                         self._on_trade_pending(
                             trade_id=trade_id,
@@ -442,9 +442,6 @@ class MartingaleStrategy(StrategyBase):
                 )
 
                 if callable(self._on_trade_result):
-                    from datetime import datetime
-
-                    placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
                     try:
                         self._on_trade_result(
                             trade_id=trade_id,

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -421,8 +421,8 @@ class OscarGrind2Strategy(StrategyBase):
                     wait_seconds = float(wait_seconds)
 
                 # GUI: ожидаем результат (две метки времени)
+                placed_at_str = datetime.now().strftime("%d.%м.%Y %H:%M:%S")
                 if callable(self._on_trade_pending):
-                    placed_at_str = datetime.now().strftime("%d.%м.%Y %H:%M:%S")
                     try:
                         self._on_trade_pending(
                             trade_id=trade_id,
@@ -453,9 +453,6 @@ class OscarGrind2Strategy(StrategyBase):
 
                 # GUI: результат
                 if callable(self._on_trade_result):
-                    from datetime import datetime
-
-                    placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
                     try:
                         self._on_trade_result(
                             trade_id=trade_id,


### PR DESCRIPTION
## Summary
- display currency symbols for stakes and profit in the main trades table
- add trade rows to the main window immediately with synchronized timers
- keep original placement time when showing trade results
- stop sending strategy data to per-strategy dialogs so their tables remain column-compatible

## Testing
- `python -m py_compile gui/main_window.py gui/trades_table_widget.py strategies/martingale.py strategies/antimartin.py strategies/fibonacci.py strategies/fixed.py strategies/oscar_grind_2.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1733a575c8322821895761f6b4bb7