### PR TITLE
Keep Moscow timezone for signal and classic trade times

### DIFF
--- a/core/ws_client.py
+++ b/core/ws_client.py
@@ -8,6 +8,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
+from zoneinfo import ZoneInfo
 
 import websockets
 from PyQt6.QtWidgets import QApplication, QMessageBox
@@ -15,6 +16,7 @@ from PyQt6.QtWidgets import QApplication, QMessageBox
 from core.signal_waiter import push_signal  # без изменения сигнатуры
 
 signal_log_callback = None
+MOSCOW_TZ = ZoneInfo("Europe/Moscow")
 
 _TIMEFRAME_MAP = {
     "M1": 1,
@@ -98,10 +100,14 @@ def _parse_message(message: str) -> Optional[SignalMessage]:
         return None
 
     direction = _parse_direction(data.get("direction"))
-    timestamp = datetime.fromisoformat(dt_str)
+    timestamp = datetime.fromisoformat(dt_str).astimezone(MOSCOW_TZ)
 
     next_ts = _parse_dt_opt(data.get("next_datetime"))
+    if next_ts:
+        next_ts = next_ts.astimezone(MOSCOW_TZ)
     next2_ts = _parse_dt_opt(data.get("next2_datetime"))
+    if next2_ts:
+        next2_ts = next2_ts.astimezone(MOSCOW_TZ)
 
     return SignalMessage(
         symbol=symbol,
@@ -140,12 +146,12 @@ async def listen_to_signals() -> None:
                     )
 
                     # Лог: время без таймзоны (локально-наивное)
-                    dt_naive = sig.timestamp.replace(tzinfo=None)
+                    dt_naive = sig.timestamp.astimezone(MOSCOW_TZ).replace(tzinfo=None)
                     msg_dir = {1: "UP", 2: "DOWN", None: "none"}[sig.direction]
                     tail = ""
                     if sig.next_timestamp and sig.next2_timestamp:
-                        n1 = sig.next_timestamp.replace(tzinfo=None).strftime("%H:%M")
-                        n2 = sig.next2_timestamp.replace(tzinfo=None).strftime("%H:%M")
+                        n1 = sig.next_timestamp.astimezone(MOSCOW_TZ).strftime("%H:%M")
+                        n2 = sig.next2_timestamp.astimezone(MOSCOW_TZ).strftime("%H:%M")
                         tail = f" | next: {n1}, next2: {n2}"
                     _log(
                         f"[WS] {sig.symbol} / {sig.timeframe}. Прогноз: {msg_dir} от {sig.indicator}. "

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from core.http_async import HttpClient
 from core.intrade_api_async import (
@@ -15,6 +16,8 @@ from core.signal_waiter import wait_for_signal_versioned, peek_signal_state
 from strategies.base import StrategyBase
 from core.money import format_amount
 from core.policy import normalize_sprint
+
+MOSCOW_TZ = ZoneInfo("Europe/Moscow")
 
 ALL_SYMBOLS_LABEL = "Все валютные пары"
 ALL_TF_LABEL = "Все таймфреймы"
@@ -392,7 +395,10 @@ class AntiMartingaleStrategy(StrategyBase):
                     and self._next_expire_dt is not None
                 ):
                     trade_seconds = max(
-                        0.0, (self._next_expire_dt - datetime.now()).total_seconds()
+                        0.0,
+                        (
+                            self._next_expire_dt - datetime.now(MOSCOW_TZ)
+                        ).total_seconds(),
                     )
                     expected_end_ts = self._next_expire_dt.timestamp()
                 else:
@@ -550,7 +556,7 @@ class AntiMartingaleStrategy(StrategyBase):
         self._last_indicator = (meta or {}).get("indicator") or "-"
 
         ts = (meta or {}).get("next_timestamp")
-        self._next_expire_dt = ts.astimezone().replace(tzinfo=None) if ts else None
+        self._next_expire_dt = ts.astimezone(MOSCOW_TZ) if ts else None
 
         sig_symbol = (meta or {}).get("symbol") or self.symbol
         sig_tf = (meta or {}).get("timeframe") or self.timeframe
@@ -562,7 +568,7 @@ class AntiMartingaleStrategy(StrategyBase):
 
         from datetime import datetime
 
-        self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+        self._last_signal_at_str = datetime.now(MOSCOW_TZ).strftime("%d.%m.%Y %H:%M:%S")
         return int(direction)
 
     def update_params(self, **params):

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -5,6 +5,7 @@ import asyncio
 from typing import Optional
 
 from strategies.martingale import MartingaleStrategy, DEFAULTS as MG_DEFAULTS
+from zoneinfo import ZoneInfo
 from core.http_async import HttpClient
 from core.intrade_api_async import (
     get_balance_info,
@@ -14,6 +15,8 @@ from core.intrade_api_async import (
     is_demo_account,
 )
 from core.money import format_amount
+
+MOSCOW_TZ = ZoneInfo("Europe/Moscow")
 
 # Переиспользуем функции ожидания сигнала и прочие методы из MartingaleStrategy
 # через наследование. Здесь определяем собственные значения по умолчанию
@@ -321,7 +324,10 @@ class FibonacciStrategy(MartingaleStrategy):
                     and self._next_expire_dt is not None
                 ):
                     trade_seconds = max(
-                        0.0, (self._next_expire_dt - datetime.now()).total_seconds()
+                        0.0,
+                        (
+                            self._next_expire_dt - datetime.now(MOSCOW_TZ)
+                        ).total_seconds(),
                     )
                     expected_end_ts = self._next_expire_dt.timestamp()
                 else:

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from core.http_async import HttpClient
 from core.intrade_api_async import (
@@ -16,6 +17,8 @@ from core.signal_waiter import wait_for_signal_versioned, peek_signal_state
 from strategies.base import StrategyBase
 from core.money import format_amount
 from core.policy import normalize_sprint
+
+MOSCOW_TZ = ZoneInfo("Europe/Moscow")
 
 ALL_SYMBOLS_LABEL = "Все валютные пары"
 ALL_TF_LABEL = "Все таймфреймы"
@@ -376,7 +379,10 @@ class FixedStakeStrategy(StrategyBase):
 
             if self._trade_type == "classic" and self._next_expire_dt is not None:
                 trade_seconds = max(
-                    0.0, (self._next_expire_dt - datetime.now()).total_seconds()
+                    0.0,
+                    (
+                        self._next_expire_dt - datetime.now(MOSCOW_TZ)
+                    ).total_seconds(),
                 )
                 expected_end_ts = self._next_expire_dt.timestamp()
             else:
@@ -478,7 +484,7 @@ class FixedStakeStrategy(StrategyBase):
         self._last_indicator = (meta or {}).get("indicator") or "-"
 
         ts = (meta or {}).get("next_timestamp")
-        self._next_expire_dt = ts.astimezone().replace(tzinfo=None) if ts else None
+        self._next_expire_dt = ts.astimezone(MOSCOW_TZ) if ts else None
 
         sig_symbol = (meta or {}).get("symbol") or self.symbol
         sig_tf = (meta or {}).get("timeframe") or self.timeframe
@@ -490,7 +496,7 @@ class FixedStakeStrategy(StrategyBase):
 
         from datetime import datetime
 
-        self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+        self._last_signal_at_str = datetime.now(MOSCOW_TZ).strftime("%d.%m.%Y %H:%M:%S")
         return int(direction)
 
     def update_params(self, **params):

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from core.http_async import HttpClient
 from core.intrade_api_async import (
@@ -16,6 +17,8 @@ from core.signal_waiter import wait_for_signal_versioned, peek_signal_state
 from strategies.base import StrategyBase
 from core.money import format_amount
 from core.policy import normalize_sprint
+
+MOSCOW_TZ = ZoneInfo("Europe/Moscow")
 
 ALL_SYMBOLS_LABEL = "Все валютные пары"
 ALL_TF_LABEL = "Все таймфреймы"
@@ -397,7 +400,10 @@ class MartingaleStrategy(StrategyBase):
                     and self._next_expire_dt is not None
                 ):
                     trade_seconds = max(
-                        0.0, (self._next_expire_dt - datetime.now()).total_seconds()
+                        0.0,
+                        (
+                            self._next_expire_dt - datetime.now(MOSCOW_TZ)
+                        ).total_seconds(),
                     )
                     expected_end_ts = self._next_expire_dt.timestamp()
                 else:
@@ -556,7 +562,7 @@ class MartingaleStrategy(StrategyBase):
         self._last_indicator = (meta or {}).get("indicator") or "-"
 
         ts = (meta or {}).get("next_timestamp")
-        self._next_expire_dt = ts.astimezone().replace(tzinfo=None) if ts else None
+        self._next_expire_dt = ts.astimezone(MOSCOW_TZ) if ts else None
 
         sig_symbol = (meta or {}).get("symbol") or self.symbol
         sig_tf = (meta or {}).get("timeframe") or self.timeframe
@@ -568,7 +574,7 @@ class MartingaleStrategy(StrategyBase):
 
         from datetime import datetime
 
-        self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+        self._last_signal_at_str = datetime.now(MOSCOW_TZ).strftime("%d.%m.%Y %H:%M:%S")
         return int(direction)
 
     def update_params(self, **params):

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import math
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from core.http_async import HttpClient
 from core.intrade_api_async import (
@@ -17,6 +18,8 @@ from core.signal_waiter import wait_for_signal_versioned, peek_signal_state
 from strategies.base import StrategyBase
 from core.policy import normalize_sprint
 from core.money import format_amount
+
+MOSCOW_TZ = ZoneInfo("Europe/Moscow")
 
 # Берём вспомогательные вещи из мартингейла, чтобы не дублировать
 from strategies.martingale import (
@@ -407,7 +410,10 @@ class OscarGrind2Strategy(StrategyBase):
                     and self._next_expire_dt is not None
                 ):
                     trade_seconds = max(
-                        0.0, (self._next_expire_dt - datetime.now()).total_seconds()
+                        0.0,
+                        (
+                            self._next_expire_dt - datetime.now(MOSCOW_TZ)
+                        ).total_seconds(),
                     )
                     expected_end_ts = self._next_expire_dt.timestamp()
                 else:
@@ -623,7 +629,7 @@ class OscarGrind2Strategy(StrategyBase):
         self._last_indicator = (meta or {}).get("indicator") or "-"
 
         ts = (meta or {}).get("next_timestamp")
-        self._next_expire_dt = ts.astimezone().replace(tzinfo=None) if ts else None
+        self._next_expire_dt = ts.astimezone(MOSCOW_TZ) if ts else None
 
         sig_symbol = (meta or {}).get("symbol") or self.symbol
         sig_tf = (meta or {}).get("timeframe") or self.timeframe
@@ -635,7 +641,7 @@ class OscarGrind2Strategy(StrategyBase):
 
         from datetime import datetime
 
-        self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+        self._last_signal_at_str = datetime.now(MOSCOW_TZ).strftime("%d.%m.%Y %H:%M:%S")
         return int(direction)
 
     def update_params(self, **params):


### PR DESCRIPTION
## Summary
- preserve Moscow timezone when parsing and logging WebSocket signal times
- compute classic trade expiration using Moscow time across strategies

## Testing
- `python -m py_compile core/ws_client.py strategies/martingale.py strategies/antimartin.py strategies/oscar_grind_2.py strategies/fixed.py strategies/fibonacci.py`


------
https://chatgpt.com/codex/tasks/task_e_68b179dd278083229ca7e0267ecb64f4