### PR TITLE
Fix column resizing and local time display

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -193,7 +193,8 @@ class MainWindow(QWidget):
             ]
         )
         hdr = self.bot_table.horizontalHeader()
-        hdr.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        hdr.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        hdr.setStretchLastSection(False)
         self.bot_table.setAlternatingRowColors(True)
         self.bot_table.setSortingEnabled(False)
         self.bot_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)

--- a/gui/trades_table_widget.py
+++ b/gui/trades_table_widget.py
@@ -45,10 +45,11 @@ class TradesTableWidget(QTableWidget):
         self.setHorizontalHeaderLabels(self.COLS)
 
         hdr = self.horizontalHeader()
-        hdr.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        hdr.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        hdr.setStretchLastSection(False)
 
         self.setAlternatingRowColors(True)
-        self.setSortingEnabled(True)
+        self.setSortingEnabled(False)
         self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self.setSelectionMode(QTableWidget.SelectionMode.NoSelection)
         self.setFocusPolicy(Qt.FocusPolicy.NoFocus)

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -583,7 +583,7 @@ class AntiMartingaleStrategy(StrategyBase):
 
             from datetime import datetime
 
-            self._last_signal_at_str = datetime.now(MOSCOW_TZ).strftime(
+            self._last_signal_at_str = datetime.now().strftime(
                 "%d.%m.%Y %H:%M:%S"
             )
             return int(direction)

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -511,7 +511,7 @@ class FixedStakeStrategy(StrategyBase):
 
             from datetime import datetime
 
-            self._last_signal_at_str = datetime.now(MOSCOW_TZ).strftime(
+            self._last_signal_at_str = datetime.now().strftime(
                 "%d.%m.%Y %H:%M:%S"
             )
             return int(direction)

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -596,7 +596,7 @@ class MartingaleStrategy(StrategyBase):
 
             from datetime import datetime
 
-            self._last_signal_at_str = datetime.now(MOSCOW_TZ).strftime(
+            self._last_signal_at_str = datetime.now().strftime(
                 "%d.%m.%Y %H:%M:%S"
             )
             return int(direction)

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -656,7 +656,7 @@ class OscarGrind2Strategy(StrategyBase):
 
             from datetime import datetime
 
-            self._last_signal_at_str = datetime.now(MOSCOW_TZ).strftime(
+            self._last_signal_at_str = datetime.now().strftime(
                 "%d.%m.%Y %H:%M:%S"
             )
             return int(direction)


### PR DESCRIPTION
## Summary
- Disable sorting and switch trades table columns to ResizeToContents to avoid shrinking
- Apply ResizeToContents to bots table header for consistent column widths
- Record signal time using local timezone instead of Moscow time to avoid MSK display for classic trades

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b19207e9108322b8f0c1cdeea40b9e