### PR TITLE
Default to Classic trades and relax signal freshness

### DIFF
--- a/core/signal_waiter.py
+++ b/core/signal_waiter.py
@@ -129,6 +129,7 @@ async def wait_for_signal_versioned(
     on_delay: Optional[Callable[[float], None]] = None,  # callback(delay_seconds)
     # --- новое: вернуть вместе с direction/version ещё и meta (indicator, tf_sec, symbol, timeframe) ---
     include_meta: bool = False,
+    max_age_sec: float = 0.0,
 ) -> Tuple[int, int] | Tuple[int, int, Dict[str, Optional[str | int | float]]]:
     """
     Ждёт ПЕРВЫЙ up/down с версией > since_version.
@@ -137,17 +138,19 @@ async def wait_for_signal_versioned(
 
     Если include_meta=True — вернёт (direction, version, meta),
     где meta = {"indicator": str|None, "tf_sec": int|None, "symbol": str|None, "timeframe": str|None}.
+    max_age_sec > 0 позволяет использовать сигнал, пришедший не ранее чем
+    max_age_sec секунд до вызова функции.
     """
     st = _states[_key(symbol, timeframe)]
     start = asyncio.get_running_loop().time()
 
     async def _await_next_change() -> Tuple[Optional[int], int]:
         async with st.cond:
-            # быстрый путь — только если сигнал пришёл ПОСЛЕ start
+            # быстрый путь — только если сигнал пришёл ПОСЛЕ start-max_age_sec
             if (
                 st.value in (1, 2)
                 and (since_version is None or st.version > since_version)
-                and (st.last_monotonic or 0) >= start
+                and (st.last_monotonic or 0) >= (start - float(max_age_sec))
             ):
                 return st.value, st.version
             # иначе ждём новое сообщение
@@ -195,7 +198,7 @@ async def wait_for_signal_versioned(
             direction in (1, 2)
             and (since_version is None or ver > since_version)
             and st.last_monotonic is not None
-            and st.last_monotonic >= start
+            and st.last_monotonic >= (start - float(max_age_sec))
         ):
                 if include_meta:
                     meta = {

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -122,7 +122,7 @@ class StrategyControlDialog(QDialog):
 
         self.trade_type = QComboBox()
         self.trade_type.addItems(["sprint", "classic"])
-        self.trade_type.setCurrentText(str(getv("trade_type", "sprint")))
+        self.trade_type.setCurrentText(str(getv("trade_type", "classic")))
         allowed_classic = {ALL_TF_LABEL, "M5", "M15", "M30", "H1", "H4"}
         if tf not in allowed_classic:
             idx = self.trade_type.findText("classic")

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -34,7 +34,7 @@ DEFAULTS = {
     "account_currency": "RUB",
     "result_wait_s": 60.0,
     "grace_delay_sec": 30.0,
-    "trade_type": "sprint",
+    "trade_type": "classic",
 }
 
 
@@ -368,22 +368,33 @@ class AntiMartingaleStrategy(StrategyBase):
                         continue
                     time_arg = self._next_expire_dt.strftime("%H:%M")
                     trade_kwargs["date"] = self._next_expire_dt.strftime("%d-%m-%Y")
-                trade_id = await place_trade(
-                    self.http_client,
-                    user_id=self.user_id,
-                    user_hash=self.user_hash,
-                    investment=stake,
-                    option=self.symbol,
-                    status=status,
-                    minutes=time_arg,
-                    account_ccy=account_ccy,
-                    strict=True,
-                    on_log=log,
-                    **trade_kwargs,
-                )
+                attempt = 0
+                trade_id = None
+                while attempt < 4:
+                    trade_id = await place_trade(
+                        self.http_client,
+                        user_id=self.user_id,
+                        user_hash=self.user_hash,
+                        investment=stake,
+                        option=self.symbol,
+                        status=status,
+                        minutes=time_arg,
+                        account_ccy=account_ccy,
+                        strict=True,
+                        on_log=log,
+                        **trade_kwargs,
+                    )
+                    if trade_id:
+                        break
+                    attempt += 1
+                    if attempt < 4:
+                        log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
+                        await self.sleep(1.0)
                 if not trade_id:
-                    log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
-                    await self.sleep(1.0)
+                    log(
+                        f"[{self.symbol}] ❌ Не удалось разместить сделку после 4 попыток. Ждём новый сигнал."
+                    )
+                    series_direction = None
                     continue
 
                 did_place_any_trade = True
@@ -551,6 +562,7 @@ class AntiMartingaleStrategy(StrategyBase):
                 grace_delay_sec=grace,
                 on_delay=_on_delay,
                 include_meta=True,
+                max_age_sec=(120.0 if self._trade_type == "classic" else 0.0),
             )
 
             direction, ver, meta = await self.wait_cancellable(coro, timeout=timeout)

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -296,22 +296,33 @@ class FibonacciStrategy(MartingaleStrategy):
                         continue
                     time_arg = self._next_expire_dt.strftime("%H:%M")
                     trade_kwargs["date"] = self._next_expire_dt.strftime("%d-%m-%Y")
-                trade_id = await place_trade(
-                    self.http_client,
-                    user_id=self.user_id,
-                    user_hash=self.user_hash,
-                    investment=stake,
-                    option=self.symbol,
-                    status=status,
-                    minutes=time_arg,
-                    account_ccy=account_ccy,
-                    strict=True,
-                    on_log=log,
-                    **trade_kwargs,
-                )
+                attempt = 0
+                trade_id = None
+                while attempt < 4:
+                    trade_id = await place_trade(
+                        self.http_client,
+                        user_id=self.user_id,
+                        user_hash=self.user_hash,
+                        investment=stake,
+                        option=self.symbol,
+                        status=status,
+                        minutes=time_arg,
+                        account_ccy=account_ccy,
+                        strict=True,
+                        on_log=log,
+                        **trade_kwargs,
+                    )
+                    if trade_id:
+                        break
+                    attempt += 1
+                    if attempt < 4:
+                        log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
+                        await self.sleep(1.0)
                 if not trade_id:
-                    log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
-                    await self.sleep(1.0)
+                    log(
+                        f"[{self.symbol}] ❌ Не удалось разместить сделку после 4 попыток. Ждём новый сигнал."
+                    )
+                    series_direction = None
                     continue
 
                 did_place_any_trade = True

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -34,7 +34,7 @@ DEFAULTS = {
     "account_currency": "RUB",
     "result_wait_s": 60.0,
     "grace_delay_sec": 30.0,
-    "trade_type": "sprint",
+    "trade_type": "classic",
 }
 
 
@@ -355,22 +355,33 @@ class FixedStakeStrategy(StrategyBase):
                     continue
                 time_arg = self._next_expire_dt.strftime("%H:%M")
                 trade_kwargs["date"] = self._next_expire_dt.strftime("%d-%m-%Y")
-            trade_id = await place_trade(
-                self.http_client,
-                user_id=self.user_id,
-                user_hash=self.user_hash,
-                investment=stake,
-                option=self.symbol,
-                status=status,
-                minutes=time_arg,
-                account_ccy=account_ccy,
-                strict=True,
-                on_log=log,
-                **trade_kwargs,
-            )
+            attempt = 0
+            trade_id = None
+            while attempt < 4:
+                trade_id = await place_trade(
+                    self.http_client,
+                    user_id=self.user_id,
+                    user_hash=self.user_hash,
+                    investment=stake,
+                    option=self.symbol,
+                    status=status,
+                    minutes=time_arg,
+                    account_ccy=account_ccy,
+                    strict=True,
+                    on_log=log,
+                    **trade_kwargs,
+                )
+                if trade_id:
+                    break
+                attempt += 1
+                if attempt < 4:
+                    log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
+                    await self.sleep(1.0)
             if not trade_id:
-                log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
-                await self.sleep(1.0)
+                log(
+                    f"[{self.symbol}] ❌ Не удалось разместить сделку после 4 попыток. Ждём новый сигнал."
+                )
+                status = None
                 continue
 
             trades_left -= 1
@@ -479,6 +490,7 @@ class FixedStakeStrategy(StrategyBase):
                 grace_delay_sec=grace,
                 on_delay=_on_delay,
                 include_meta=True,
+                max_age_sec=(120.0 if self._trade_type == "classic" else 0.0),
             )
 
             direction, ver, meta = await self.wait_cancellable(coro, timeout=timeout)

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -36,7 +36,7 @@ DEFAULTS = {
     "account_currency": "RUB",
     "result_wait_s": 60.0,
     "grace_delay_sec": 30.0,
-    "trade_type": "sprint",
+    "trade_type": "classic",
 }
 
 
@@ -373,22 +373,33 @@ class MartingaleStrategy(StrategyBase):
                         continue
                     time_arg = self._next_expire_dt.strftime("%H:%M")
                     trade_kwargs["date"] = self._next_expire_dt.strftime("%d-%m-%Y")
-                trade_id = await place_trade(
-                    self.http_client,
-                    user_id=self.user_id,
-                    user_hash=self.user_hash,
-                    investment=stake,
-                    option=self.symbol,
-                    status=status,
-                    minutes=time_arg,
-                    account_ccy=account_ccy,
-                    strict=True,
-                    on_log=log,
-                    **trade_kwargs,
-                )
+                attempt = 0
+                trade_id = None
+                while attempt < 4:
+                    trade_id = await place_trade(
+                        self.http_client,
+                        user_id=self.user_id,
+                        user_hash=self.user_hash,
+                        investment=stake,
+                        option=self.symbol,
+                        status=status,
+                        minutes=time_arg,
+                        account_ccy=account_ccy,
+                        strict=True,
+                        on_log=log,
+                        **trade_kwargs,
+                    )
+                    if trade_id:
+                        break
+                    attempt += 1
+                    if attempt < 4:
+                        log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
+                        await self.sleep(1.0)
                 if not trade_id:
-                    log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
-                    await self.sleep(1.0)
+                    log(
+                        f"[{self.symbol}] ❌ Не удалось разместить сделку после 4 попыток. Ждём новый сигнал."
+                    )
+                    series_direction = None
                     continue
 
                 did_place_any_trade = True
@@ -564,6 +575,7 @@ class MartingaleStrategy(StrategyBase):
                 grace_delay_sec=grace,
                 on_delay=_on_delay,
                 include_meta=True,
+                max_age_sec=(120.0 if self._trade_type == "classic" else 0.0),
             )
 
             direction, ver, meta = await self.wait_cancellable(coro, timeout=timeout)

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -49,7 +49,7 @@ DEFAULTS = {
     "grace_delay_sec": 30.0,
     # Поведение серии: фиксировать направление по первому сигналу (как в мартингейле)
     "lock_direction_to_first": True,
-    "trade_type": "sprint",
+    "trade_type": "classic",
 }
 
 
@@ -385,22 +385,33 @@ class OscarGrind2Strategy(StrategyBase):
                         continue
                     time_arg = self._next_expire_dt.strftime("%H:%M")
                     trade_kwargs["date"] = self._next_expire_dt.strftime("%d-%m-%Y")
-                trade_id = await place_trade(
-                    self.http_client,
-                    user_id=self.user_id,
-                    user_hash=self.user_hash,
-                    investment=stake,
-                    option=self.symbol,
-                    status=status,
-                    minutes=time_arg,
-                    account_ccy=account_ccy,
-                    strict=True,
-                    on_log=log,
-                    **trade_kwargs,
-                )
+                attempt = 0
+                trade_id = None
+                while attempt < 4:
+                    trade_id = await place_trade(
+                        self.http_client,
+                        user_id=self.user_id,
+                        user_hash=self.user_hash,
+                        investment=stake,
+                        option=self.symbol,
+                        status=status,
+                        minutes=time_arg,
+                        account_ccy=account_ccy,
+                        strict=True,
+                        on_log=log,
+                        **trade_kwargs,
+                    )
+                    if trade_id:
+                        break
+                    attempt += 1
+                    if attempt < 4:
+                        log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
+                        await self.sleep(1.0)
                 if not trade_id:
-                    log(f"[{self.symbol}] ❌ Сделка не размещена. Пауза и повтор.")
-                    await self.sleep(1.0)
+                    log(
+                        f"[{self.symbol}] ❌ Не удалось разместить сделку после 4 попыток. Ждём новый сигнал."
+                    )
+                    series_direction = None
                     continue
 
                 # определяем длительность сделки (для таймера и ожидания результата)
@@ -624,6 +635,7 @@ class OscarGrind2Strategy(StrategyBase):
                 grace_delay_sec=grace,
                 on_delay=_on_delay,
                 include_meta=True,
+                max_age_sec=(120.0 if self._trade_type == "classic" else 0.0),
             )
 
             direction, ver, meta = await self.wait_cancellable(coro, timeout=timeout)


### PR DESCRIPTION
## Summary
- Default strategy controls and configurations to Classic trading
- Allow Classic strategies to use signals up to two minutes old
- Retry failed trade placements up to three times before waiting for a new signal

## Testing
- `python -m py_compile gui/strategy_control_dialog.py core/signal_waiter.py strategies/martingale.py strategies/fibonacci.py strategies/antimartin.py strategies/fixed.py strategies/oscar_grind_2.py`


------
https://chatgpt.com/codex/tasks/task_e_68b197a1b9988322bf16b4811cad8a31