### PR TITLE
Fix table widths and trade cleanup

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -117,6 +117,7 @@ class MainWindow(QWidget):
         self.bot_log_listeners = defaultdict(list)
         self.bot_trade_listeners = defaultdict(list)
         self.bot_trade_history = defaultdict(list)
+        self.bot_pending_trades = defaultdict(set)
         self.bot_last_phase: dict[Bot, str] = {}
 
         self.user_id_label = QLabel("user_id: loading...")
@@ -193,8 +194,8 @@ class MainWindow(QWidget):
             ]
         )
         hdr = self.bot_table.horizontalHeader()
-        hdr.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setStretchLastSection(False)
+        hdr.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        hdr.setStretchLastSection(True)
         self.bot_table.setAlternatingRowColors(True)
         self.bot_table.setSortingEnabled(False)
         self.bot_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
@@ -494,6 +495,13 @@ class MainWindow(QWidget):
             for b, r in list(self.bot_rows.items()):
                 if r > row:
                     self.bot_rows[b] = r - 1
+
+        pending_ids = self.bot_pending_trades.pop(bot, set())
+        for tid in pending_ids:
+            try:
+                self.trades_table.set_result(str(tid), None, self.account_currency)
+            except Exception:
+                pass
         for mp in (
             self.bot_started_at,
             self.bot_profit,
@@ -855,6 +863,10 @@ class MainWindow(QWidget):
         except Exception as e:
             self.append_to_log(f"[!] Ошибка обновления профита: {e}")
 
+        tid = str(kw.get("trade_id", ""))
+        if tid:
+            self.bot_pending_trades.get(bot, set()).discard(tid)
+
         # дальше — обычное добавление в таблицу сделок
         key = bot.strategy_kwargs.get("strategy_key", "")
         strat_label = self.strategy_label(key)
@@ -889,6 +901,10 @@ class MainWindow(QWidget):
             self.add_trade_pending(**payload)
         except Exception:
             pass
+
+        tid = str(payload.get("trade_id", ""))
+        if tid:
+            self.bot_pending_trades[bot].add(tid)
 
         # ⬇️ НОВОЕ: сохраняем в историю, чтобы StrategyControlDialog восстановил «ожидание»
         self.bot_trade_history[bot].append(("pending", dict(payload)))

--- a/gui/trades_table_widget.py
+++ b/gui/trades_table_widget.py
@@ -45,8 +45,8 @@ class TradesTableWidget(QTableWidget):
         self.setHorizontalHeaderLabels(self.COLS)
 
         hdr = self.horizontalHeader()
-        hdr.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
-        hdr.setStretchLastSection(False)
+        hdr.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        hdr.setStretchLastSection(True)
 
         self.setAlternatingRowColors(True)
         self.setSortingEnabled(False)

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -592,6 +592,10 @@ class AntiMartingaleStrategy(StrategyBase):
             if self._use_any_timeframe:
                 self.timeframe = sig_tf
                 self.params["timeframe"] = self.timeframe
+                raw = _minutes_from_timeframe(self.timeframe)
+                norm = normalize_sprint(self.symbol, raw) or raw
+                self._trade_minutes = int(norm)
+                self.params["minutes"] = self._trade_minutes
 
             from datetime import datetime
 
@@ -627,6 +631,11 @@ class AntiMartingaleStrategy(StrategyBase):
             self._use_any_timeframe = tf_raw in (ALL_TF_LABEL, "*")
             self.timeframe = "*" if self._use_any_timeframe else tf
             self.params["timeframe"] = self.timeframe
+            if "minutes" not in params:
+                raw = _minutes_from_timeframe(self.timeframe)
+                norm = normalize_sprint(self.symbol, raw) or raw
+                self._trade_minutes = int(norm)
+                self.params["minutes"] = self._trade_minutes
 
         if "account_currency" in params:
             want = str(params["account_currency"]).upper()

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -520,6 +520,10 @@ class FixedStakeStrategy(StrategyBase):
             if self._use_any_timeframe:
                 self.timeframe = sig_tf
                 self.params["timeframe"] = self.timeframe
+                raw = _minutes_from_timeframe(self.timeframe)
+                norm = normalize_sprint(self.symbol, raw) or raw
+                self._trade_minutes = int(norm)
+                self.params["minutes"] = self._trade_minutes
 
             from datetime import datetime
 
@@ -555,6 +559,11 @@ class FixedStakeStrategy(StrategyBase):
             self._use_any_timeframe = tf_raw in (ALL_TF_LABEL, "*")
             self.timeframe = "*" if self._use_any_timeframe else tf
             self.params["timeframe"] = self.timeframe
+            if "minutes" not in params:
+                raw = _minutes_from_timeframe(self.timeframe)
+                norm = normalize_sprint(self.symbol, raw) or raw
+                self._trade_minutes = int(norm)
+                self.params["minutes"] = self._trade_minutes
 
         if "account_currency" in params:
             want = str(params["account_currency"]).upper()

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -605,6 +605,10 @@ class MartingaleStrategy(StrategyBase):
             if self._use_any_timeframe:
                 self.timeframe = sig_tf
                 self.params["timeframe"] = self.timeframe
+                raw = _minutes_from_timeframe(self.timeframe)
+                norm = normalize_sprint(self.symbol, raw) or raw
+                self._trade_minutes = int(norm)
+                self.params["minutes"] = self._trade_minutes
 
             from datetime import datetime
 
@@ -640,6 +644,11 @@ class MartingaleStrategy(StrategyBase):
             self._use_any_timeframe = tf_raw in (ALL_TF_LABEL, "*")
             self.timeframe = "*" if self._use_any_timeframe else tf
             self.params["timeframe"] = self.timeframe
+            if "minutes" not in params:
+                raw = _minutes_from_timeframe(self.timeframe)
+                norm = normalize_sprint(self.symbol, raw) or raw
+                self._trade_minutes = int(norm)
+                self.params["minutes"] = self._trade_minutes
 
         if "account_currency" in params:
             want = str(params["account_currency"]).upper()

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -665,6 +665,10 @@ class OscarGrind2Strategy(StrategyBase):
             if self._use_any_timeframe:
                 self.timeframe = sig_tf
                 self.params["timeframe"] = self.timeframe
+                raw = _minutes_from_timeframe(self.timeframe)
+                norm = normalize_sprint(self.symbol, raw) or raw
+                self._trade_minutes = int(norm)
+                self.params["minutes"] = self._trade_minutes
 
             from datetime import datetime
 
@@ -700,6 +704,11 @@ class OscarGrind2Strategy(StrategyBase):
             self._use_any_timeframe = tf_raw in (ALL_TF_LABEL, "*")
             self.timeframe = "*" if self._use_any_timeframe else tf
             self.params["timeframe"] = self.timeframe
+            if "minutes" not in params:
+                raw = _minutes_from_timeframe(self.timeframe)
+                norm = normalize_sprint(self.symbol, raw) or raw
+                self._trade_minutes = int(norm)
+                self.params["minutes"] = self._trade_minutes
 
         if "account_currency" in params:
             want = str(params["account_currency"]).upper()


### PR DESCRIPTION
## Summary
- stretch bot and trades tables to full width
- close pending trades when bots are removed
- log actual trade minutes instead of default 1

## Testing
- `python -m py_compile gui/main_window.py gui/trades_table_widget.py strategies/antimartin.py strategies/fixed.py strategies/martingale.py strategies/oscar_grind_2.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1cd9f79988322bb1e13f8085f8a5c