### PR TITLE
Allow Classic trade type for all timeframes

### DIFF
--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -123,7 +123,7 @@ class StrategyControlDialog(QDialog):
         self.trade_type = QComboBox()
         self.trade_type.addItems(["sprint", "classic"])
         self.trade_type.setCurrentText(str(getv("trade_type", "classic")))
-        allowed_classic = {ALL_TF_LABEL, "M5", "M15", "M30", "H1", "H4"}
+        allowed_classic = {ALL_TF_LABEL, "*", "M5", "M15", "M30", "H1", "H4"}
         if tf not in allowed_classic:
             idx = self.trade_type.findText("classic")
             if idx >= 0:


### PR DESCRIPTION
## Summary
- Ensure classic trade type remains selectable when strategy timeframe is set to all timeframes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1d1cbe74c8322bc65f29ac051e948