### PR TITLE
Improve balance formatting and bot creation UI

### DIFF
--- a/gui/bot_add_dialog.py
+++ b/gui/bot_add_dialog.py
@@ -1,11 +1,16 @@
 from PyQt6.QtWidgets import (
     QDialog,
     QVBoxLayout,
+    QHBoxLayout,
     QComboBox,
     QDialogButtonBox,
     QLabel,
     QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QTextEdit,
 )
+from PyQt6.QtCore import Qt
 
 ALL_SYMBOLS_LABEL = "Все валютные пары"
 ALL_TF_LABEL = "Все таймфреймы"
@@ -30,12 +35,20 @@ class AddBotDialog(QDialog):
 
         # Сначала выбор алгоритма
         layout.addWidget(QLabel("Алгоритм:"))
-        self.strategy_combo = QComboBox()
+        algo_layout = QHBoxLayout()
+        self.strategy_list = QListWidget()
         for key in self.available_strategies.keys():
             label = self.strategy_labels.get(key, key)
-            self.strategy_combo.addItem(label, userData=key)
-        layout.addWidget(self.strategy_combo)
-        self.strategy_combo.currentIndexChanged.connect(self.on_strategy_change)
+            item = QListWidgetItem(label)
+            item.setData(Qt.ItemDataRole.UserRole, key)
+            self.strategy_list.addItem(item)
+        algo_layout.addWidget(self.strategy_list)
+        self.strategy_desc = QTextEdit()
+        self.strategy_desc.setReadOnly(True)
+        algo_layout.addWidget(self.strategy_desc)
+        layout.addLayout(algo_layout)
+        self.strategy_list.currentRowChanged.connect(self.on_strategy_change)
+        self.strategy_list.setCurrentRow(0)
 
         # Поиск валют
         layout.addWidget(QLabel("Поиск валютной пары:"))
@@ -88,7 +101,13 @@ class AddBotDialog(QDialog):
         self.on_strategy_change()
 
     def on_strategy_change(self, *_):
-        pass
+        key = self.selected_strategy
+        desc = ""
+        if key:
+            cls = self.available_strategies.get(key)
+            if cls and cls.__doc__:
+                desc = cls.__doc__.strip()
+        self.strategy_desc.setText(desc)
 
     @property
     def selected_symbol(self):
@@ -100,7 +119,10 @@ class AddBotDialog(QDialog):
 
     @property
     def selected_strategy(self):
-        return self.strategy_combo.currentData()
+        item = self.strategy_list.currentItem()
+        if item:
+            return item.data(Qt.ItemDataRole.UserRole)
+        return None
 
     def get_result(self):
         return self.selected_symbol, self.selected_strategy

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -272,10 +272,11 @@ class MainWindow(QWidget):
             try:
                 demo = await is_demo_account(self.http_client)
                 self.is_demo = demo
-                amount, currency, display = await get_balance_info(
+                amount, currency, _ = await get_balance_info(
                     self.http_client, self.user_id, self.user_hash
                 )
                 self.account_currency = currency
+                display = format_money(amount, currency)
 
                 if self.is_demo and "(демо)" not in display:
                     display = f"{display} (демо)"
@@ -499,7 +500,7 @@ class MainWindow(QWidget):
         pending_ids = self.bot_pending_trades.pop(bot, set())
         for tid in pending_ids:
             try:
-                self.trades_table.set_result(str(tid), None, self.account_currency)
+                self.trades_table.remove_trade(str(tid))
             except Exception:
                 pass
         for mp in (
@@ -603,10 +604,11 @@ class MainWindow(QWidget):
 
             # Сразу перечитаем статус и баланс, чтобы UI обновился мгновенно
             self.is_demo = await is_demo_account(self.http_client)
-            amount, currency, display = await get_balance_info(
+            amount, currency, _ = await get_balance_info(
                 self.http_client, self.user_id, self.user_hash
             )
             self.account_currency = currency
+            display = format_money(amount, currency)
             if self.is_demo and "(демо)" not in display:
                 display = f"{display} (демо)"
             self.balance_label.setText(f"Баланс: {display}")

--- a/gui/trades_table_widget.py
+++ b/gui/trades_table_widget.py
@@ -208,3 +208,32 @@ class TradesTableWidget(QTableWidget):
             it = self.item(row, c)
             if it:
                 it.setBackground(QBrush(row_bg))
+
+    def remove_trade(self, trade_id: str):
+        """Удаляет сделку из таблицы по её идентификатору."""
+        info = self._pending_rows.pop(trade_id, None)
+        if info:
+            timer = info.get("timer")
+            if isinstance(timer, QTimer):
+                try:
+                    timer.stop()
+                except Exception:
+                    pass
+
+        row = self._row_by_trade.pop(trade_id, None)
+        if row is None:
+            return
+        if 0 <= row < self.rowCount():
+            self.removeRow(row)
+
+        # пересчитываем индексы после удаления строки
+        self._row_by_trade = {
+            tid: (r - 1 if r > row else r) for tid, r in self._row_by_trade.items()
+        }
+        for info in self._pending_rows.values():
+            r = info.get("row")
+            if isinstance(r, int):
+                if r == row:
+                    info["row"] = None
+                elif r > row:
+                    info["row"] = r - 1


### PR DESCRIPTION
## Summary
- Format main window balance using commas and update on demo toggle
- Drop unfinished trades from history when deleting a bot
- Redesign bot creation dialog with a strategy list and description panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b54c145480832286f80a839b801345