### PR TITLE
Добавлен чекбокс "Двойной вход" для Oscar Grind

### DIFF
--- a/gui/settings_oscar_grind.py
+++ b/gui/settings_oscar_grind.py
@@ -5,6 +5,7 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QDoubleSpinBox,
     QDialogButtonBox,
+    QCheckBox,
 )
 from strategies.martingale import _minutes_from_timeframe
 from core.policy import normalize_sprint
@@ -58,14 +59,9 @@ class OscarGrindSettingsDialog(QDialog):
         self.min_percent.setRange(0, 100)
         self.min_percent.setValue(self.params.get("min_percent", 70))
 
-        # Поведение направления (фиксировать по первому сигналу)
-        self.lock_direction = QSpinBox()
-        self.lock_direction.setRange(
-            0, 1
-        )  # 1 = фиксировать, 0 = брать новый каждый раз
-        self.lock_direction.setValue(
-            1 if self.params.get("lock_direction_to_first", True) else 0
-        )
+        # Повторный вход при поражении
+        self.double_entry = QCheckBox()
+        self.double_entry.setChecked(bool(self.params.get("double_entry", False)))
 
         form = QFormLayout()
         form.addRow("Базовая ставка (unit)", self.base_investment)
@@ -75,7 +71,7 @@ class OscarGrindSettingsDialog(QDialog):
         form.addRow("Повторов серии", self.repeat_count)
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
-        form.addRow("Фиксировать направление (0/1)", self.lock_direction)
+        form.addRow("Двойной вход", self.double_entry)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -102,5 +98,5 @@ class OscarGrindSettingsDialog(QDialog):
             "repeat_count": int(self.repeat_count.value()),
             "min_balance": int(self.min_balance.value()),
             "min_percent": int(self.min_percent.value()),
-            "lock_direction_to_first": bool(self.lock_direction.value() == 1),
+            "double_entry": bool(self.double_entry.isChecked()),
         }

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -16,6 +16,7 @@ from PyQt6.QtWidgets import (
     QTableWidgetItem,
     QHeaderView,
     QComboBox,
+    QCheckBox,
 )
 from PyQt6.QtGui import QColor, QBrush
 from PyQt6.QtCore import QTimer, Qt
@@ -167,9 +168,8 @@ class StrategyControlDialog(QDialog):
             self.min_percent.setRange(0, 100)
             self.min_percent.setValue(int(getv("min_percent", 70)))
 
-            self.lock_direction = QSpinBox()
-            self.lock_direction.setRange(0, 1)
-            self.lock_direction.setValue(1 if getv("lock_direction_to_first", True) else 0)
+            self.double_entry = QCheckBox()
+            self.double_entry.setChecked(bool(getv("double_entry", False)))
 
             form.addRow("Тип торговли", self.trade_type)
             form.addRow("Базовая ставка", self.base_investment)
@@ -179,7 +179,7 @@ class StrategyControlDialog(QDialog):
             form.addRow("Повторов серии", self.repeat_count)
             form.addRow("Мин. баланс", self.min_balance)
             form.addRow("Мин. процент", self.min_percent)
-            form.addRow("Фиксировать направление (0/1)", self.lock_direction)
+            form.addRow("Двойной вход", self.double_entry)
         elif strategy_key == "fixed":
             self.minutes = QSpinBox()
             self.minutes.setRange(5 if symbol == "BTCUSDT" else 1, 500)
@@ -421,7 +421,7 @@ class StrategyControlDialog(QDialog):
                 "repeat_count": self.repeat_count.value(),
                 "min_balance": self.min_balance.value(),
                 "min_percent": self.min_percent.value(),
-                "lock_direction_to_first": bool(self.lock_direction.value() == 1),
+                "double_entry": bool(self.double_entry.isChecked()),
             }
             if trade_type != "classic":
                 new_params["minutes"] = int(norm)

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -47,8 +47,8 @@ DEFAULTS = {
     "account_currency": "RUB",
     "result_wait_s": 60.0,
     "grace_delay_sec": 30.0,
-    # Поведение серии: фиксировать направление по первому сигналу (как в мартингейле)
-    "lock_direction_to_first": True,
+    # Поведение серии: повторный вход после поражения
+    "double_entry": False,
     "trade_type": "classic",
 }
 
@@ -240,10 +240,8 @@ class OscarGrind2Strategy(StrategyBase):
             sig_timeout = float(
                 self.params.get("signal_timeout_sec", DEFAULTS["signal_timeout_sec"])
             )
-            lock_dir = bool(
-                self.params.get(
-                    "lock_direction_to_first", DEFAULTS["lock_direction_to_first"]
-                )
+            double_entry = bool(
+                self.params.get("double_entry", DEFAULTS["double_entry"])
             )
             account_ccy = self._anchor_ccy
 
@@ -259,9 +257,8 @@ class OscarGrind2Strategy(StrategyBase):
             cum_profit = 0.0  # накопленный профиль серии (может уходить в минус)
             stake = base_unit  # текущая ставка (unit-кратная)
 
-            series_direction = (
-                None  # зафиксируем по первому сигналу (как в мартингейле)
-            )
+            series_direction = None  # направление текущей ставки
+            repeat_trade = False  # повторный вход после поражения
 
             # Основной цикл серии
             while self._running and step_idx < max_steps:
@@ -316,18 +313,15 @@ class OscarGrind2Strategy(StrategyBase):
                     )
                     self._low_payout_notified = False
 
-                # Получаем (или переиспользуем) направление
-                if series_direction is None or not lock_dir:
+                # Получаем направление, если ещё не задано
+                if series_direction is None:
                     self._status("ожидание сигнала")
                     log(
                         f"[{self.symbol}] ⏳ Ожидание сигнала на {self.timeframe} (шаг {step_idx + 1})..."
                     )
                     try:
                         direction = await self.wait_signal(timeout=sig_timeout)
-                        if lock_dir and series_direction is None:
-                            series_direction = 1 if int(direction) == 1 else 2
-                        else:
-                            series_direction = 1 if int(direction) == 1 else 2
+                        series_direction = 1 if int(direction) == 1 else 2
                     except asyncio.TimeoutError:
                         log(
                             f"[{self.symbol}] ⌛ Таймаут ожидания сигнала внутри серии — выхожу из серии."
@@ -528,6 +522,14 @@ class OscarGrind2Strategy(StrategyBase):
                 # Переходим к следующему шагу
                 stake = float(next_stake)
                 step_idx += 1
+                if repeat_trade:
+                    repeat_trade = False
+                    series_direction = None
+                else:
+                    if double_entry and outcome == "loss":
+                        repeat_trade = True
+                    else:
+                        series_direction = None
                 await self.sleep(0.2)
 
             if not self._running:


### PR DESCRIPTION
## Summary
- replace lock-direction option with new `double_entry` setting for Oscar Grind strategies
- support double entry in strategy logic and GUI dialogs

## Testing
- `python -m py_compile gui/settings_oscar_grind.py gui/strategy_control_dialog.py strategies/oscar_grind_2.py strategies/oscar_grind_1.py`


------
https://chatgpt.com/codex/tasks/task_e_68b55024ff808322b7d42f6f70600628