### PR TITLE
feat: rename double entry option

### DIFF
--- a/gui/settings_oscar_grind.py
+++ b/gui/settings_oscar_grind.py
@@ -6,6 +6,7 @@ from PyQt6.QtWidgets import (
     QDoubleSpinBox,
     QDialogButtonBox,
     QCheckBox,
+    QLabel,
 )
 from strategies.martingale import _minutes_from_timeframe
 from core.policy import normalize_sprint
@@ -62,6 +63,8 @@ class OscarGrindSettingsDialog(QDialog):
         # Повторный вход при поражении
         self.double_entry = QCheckBox()
         self.double_entry.setChecked(bool(self.params.get("double_entry", False)))
+        double_entry_label = QLabel("Двойной вход на свечу")
+        double_entry_label.mousePressEvent = lambda event: self.double_entry.toggle()
 
         form = QFormLayout()
         form.addRow("Базовая ставка (unit)", self.base_investment)
@@ -71,7 +74,7 @@ class OscarGrindSettingsDialog(QDialog):
         form.addRow("Повторов серии", self.repeat_count)
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
-        form.addRow("Двойной вход", self.double_entry)
+        form.addRow(double_entry_label, self.double_entry)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -170,6 +170,8 @@ class StrategyControlDialog(QDialog):
 
             self.double_entry = QCheckBox()
             self.double_entry.setChecked(bool(getv("double_entry", False)))
+            double_entry_label = QLabel("Двойной вход на свечу")
+            double_entry_label.mousePressEvent = lambda event: self.double_entry.toggle()
 
             form.addRow("Тип торговли", self.trade_type)
             form.addRow("Базовая ставка", self.base_investment)
@@ -179,7 +181,7 @@ class StrategyControlDialog(QDialog):
             form.addRow("Повторов серии", self.repeat_count)
             form.addRow("Мин. баланс", self.min_balance)
             form.addRow("Мин. процент", self.min_percent)
-            form.addRow("Двойной вход", self.double_entry)
+            form.addRow(double_entry_label, self.double_entry)
         elif strategy_key == "fixed":
             self.minutes = QSpinBox()
             self.minutes.setRange(5 if symbol == "BTCUSDT" else 1, 500)


### PR DESCRIPTION
## Summary
- rename "Двойной вход" to "Двойной вход на свечу" for Oscar Grind strategies
- allow toggling the double-entry checkbox by clicking its label

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b553230a388322b1f1c30f99bbf5a9