### PR TITLE
Enable double entry on candle by default

### DIFF
--- a/gui/settings_oscar_grind.py
+++ b/gui/settings_oscar_grind.py
@@ -62,7 +62,7 @@ class OscarGrindSettingsDialog(QDialog):
 
         # Повторный вход при поражении
         self.double_entry = QCheckBox()
-        self.double_entry.setChecked(bool(self.params.get("double_entry", False)))
+        self.double_entry.setChecked(bool(self.params.get("double_entry", True)))
         double_entry_label = QLabel("Двойной вход на свечу")
         double_entry_label.mousePressEvent = lambda event: self.double_entry.toggle()
 

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -169,7 +169,7 @@ class StrategyControlDialog(QDialog):
             self.min_percent.setValue(int(getv("min_percent", 70)))
 
             self.double_entry = QCheckBox()
-            self.double_entry.setChecked(bool(getv("double_entry", False)))
+            self.double_entry.setChecked(bool(getv("double_entry", True)))
             double_entry_label = QLabel("Двойной вход на свечу")
             double_entry_label.mousePressEvent = lambda event: self.double_entry.toggle()
 

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -48,7 +48,7 @@ DEFAULTS = {
     "result_wait_s": 60.0,
     "grace_delay_sec": 30.0,
     # Поведение серии: повторный вход после поражения
-    "double_entry": False,
+    "double_entry": True,
     "trade_type": "classic",
 }
 


### PR DESCRIPTION
## Summary
- Enable double candle entry by default in GUI dialogs
- Default Oscar Grind strategy to double entry mode

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5546ce9388322acd3739185d15604