### PR TITLE
Remove series target from Oscar Grind strategy

### DIFF
--- a/gui/settings_oscar_grind.py
+++ b/gui/settings_oscar_grind.py
@@ -3,7 +3,6 @@ from PyQt6.QtWidgets import (
     QDialog,
     QFormLayout,
     QSpinBox,
-    QDoubleSpinBox,
     QDialogButtonBox,
     QCheckBox,
     QLabel,
@@ -23,9 +22,6 @@ class OscarGrindSettingsDialog(QDialog):
 
         default_minutes = int(self.params.get("minutes", _minutes_from_timeframe(tf)))
         base_default = int(self.params.get("base_investment", 100))
-        target_default = self.params.get("target_profit", None)
-        if target_default in (None, 0):
-            target_default = base_default
 
         # Время экспирации
         self.minutes = QSpinBox()
@@ -37,10 +33,6 @@ class OscarGrindSettingsDialog(QDialog):
         self.base_investment.setRange(1, 50000)
         self.base_investment.setValue(base_default)
 
-        # Цель серии по прибыли (в валюте счёта)
-        self.target_profit = QSpinBox()
-        self.target_profit.setRange(1, 1_000_000)
-        self.target_profit.setValue(int(target_default))
 
         # Ограничители
         self.max_steps = QSpinBox()
@@ -68,7 +60,6 @@ class OscarGrindSettingsDialog(QDialog):
 
         form = QFormLayout()
         form.addRow("Базовая ставка (unit)", self.base_investment)
-        form.addRow("Цель серии, прибыль", self.target_profit)
         form.addRow("Время экспирации (мин)", self.minutes)
         form.addRow("Макс. сделок в серии", self.max_steps)
         form.addRow("Повторов серии", self.repeat_count)
@@ -96,7 +87,6 @@ class OscarGrindSettingsDialog(QDialog):
         return {
             "minutes": int(norm),
             "base_investment": int(self.base_investment.value()),
-            "target_profit": int(self.target_profit.value()),
             "max_steps": int(self.max_steps.value()),
             "repeat_count": int(self.repeat_count.value()),
             "min_balance": int(self.min_balance.value()),

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -147,10 +147,6 @@ class StrategyControlDialog(QDialog):
             self.base_investment.setRange(1, 50_000)
             self.base_investment.setValue(int(getv("base_investment", 100)))
 
-            tgt_default = int(getv("target_profit", getv("base_investment", 100)))
-            self.target_profit = QSpinBox()
-            self.target_profit.setRange(1, 1_000_000)
-            self.target_profit.setValue(tgt_default)
 
             self.max_steps = QSpinBox()
             self.max_steps.setRange(1, 100)
@@ -175,7 +171,6 @@ class StrategyControlDialog(QDialog):
 
             form.addRow("Тип торговли", self.trade_type)
             form.addRow("Базовая ставка", self.base_investment)
-            form.addRow("Цель серии, прибыль", self.target_profit)
             form.addRow("Время сделки (мин)", self.minutes)
             form.addRow("Макс. сделок в серии", self.max_steps)
             form.addRow("Повторов серии", self.repeat_count)
@@ -418,7 +413,6 @@ class StrategyControlDialog(QDialog):
         if getattr(self, "strategy_key", "") in ("oscar_grind_1", "oscar_grind_2"):
             new_params = {
                 "base_investment": self.base_investment.value(),
-                "target_profit": self.target_profit.value(),
                 "max_steps": self.max_steps.value(),
                 "repeat_count": self.repeat_count.value(),
                 "min_balance": self.min_balance.value(),

--- a/strategies/oscar_grind_1.py
+++ b/strategies/oscar_grind_1.py
@@ -23,14 +23,13 @@ class OscarGrind1Strategy(OscarGrind2Strategy):
         need: float,
         profit: float,
         cum_profit: float,
-        target_profit: float,
         log,
     ) -> float:
         if outcome == "win":
             next_stake = stake + base_unit
             log(
                 f"[{self.symbol}] ✅ WIN: profit={format_amount(profit)}. "
-                f"Накоплено {format_amount(cum_profit)}/{format_amount(target_profit)}. "
+                f"Накоплено {format_amount(cum_profit)}/{format_amount(base_unit)}. "
                 f"Следующая ставка = stake+unit → {format_amount(next_stake)}"
             )
         else:

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -33,8 +33,6 @@ CLASSIC_ALLOWED_TFS = {"M5", "M15", "M30", "H1", "H4"}
 DEFAULTS = {
     # Базовая «единица» ставки (unit)
     "base_investment": 100,
-    # Цель серии по прибыли (в валюте счёта). По умолчанию == base_investment
-    "target_profit": None,  # если None — будет подставлено base_investment при инициализации
     # Ограничения/повторения
     "max_steps": 20,  # максимум сделок в серии
     "repeat_count": 10,  # сколько серий подряд выполнять
@@ -76,10 +74,6 @@ class OscarGrind2Strategy(StrategyBase):
         p = dict(DEFAULTS)
         if params:
             p.update(params)
-
-        # Если цель не задана — равна base_investment
-        if p.get("target_profit") in (None, 0):
-            p["target_profit"] = float(p.get("base_investment", 100))
 
         _symbol = (symbol or "").strip()
         _tf_raw = (timeframe or "").strip()
@@ -229,9 +223,7 @@ class OscarGrind2Strategy(StrategyBase):
 
             # Параметры серии
             base_unit = float(self.params.get("base_investment", 100))
-            target_profit = float(
-                self.params.get("target_profit", base_unit)
-            )  # цель профита в валюте счёта
+            target_profit = base_unit  # цель профита в валюте счёта
             max_steps = int(self.params.get("max_steps", DEFAULTS["max_steps"]))
             min_pct = int(self.params.get("min_percent", DEFAULTS["min_percent"]))
             wait_low = float(
@@ -515,7 +507,6 @@ class OscarGrind2Strategy(StrategyBase):
                     need=need,
                     profit=0.0 if profit is None else float(profit),
                     cum_profit=cum_profit,
-                    target_profit=target_profit,
                     log=log,
                 )
 
@@ -561,7 +552,6 @@ class OscarGrind2Strategy(StrategyBase):
         need: float,
         profit: float,
         cum_profit: float,
-        target_profit: float,
         log,
     ) -> float:
         k = pct / 100.0
@@ -570,7 +560,7 @@ class OscarGrind2Strategy(StrategyBase):
             next_stake = max(base_unit, min(stake + base_unit, float(next_req)))
             log(
                 f"[{self.symbol}] ✅ WIN: profit={format_amount(profit)}. "
-                f"Накоплено {format_amount(cum_profit)}/{format_amount(target_profit)}. "
+                f"Накоплено {format_amount(cum_profit)}/{format_amount(base_unit)}. "
                 f"Следующая ставка = min(stake+unit, req) → {format_amount(stake + base_unit)} / {format_amount(next_req)} = {format_amount(next_stake)}"
             )
         else:
@@ -725,11 +715,3 @@ class OscarGrind2Strategy(StrategyBase):
             self._trade_type = str(params["trade_type"]).lower()
             self.params["trade_type"] = self._trade_type
 
-        if "base_investment" in params and "target_profit" not in params:
-            # если юзер поменял unit, а цель оставил None — синхронизируем цель с unit
-            try:
-                unit = float(params["base_investment"])
-            except Exception:
-                unit = float(self.params.get("base_investment", 100))
-            if self.params.get("target_profit") in (None, 0):
-                self.params["target_profit"] = unit


### PR DESCRIPTION
## Summary
- End Oscar Grind series once cumulative profit reaches the initial stake
- Drop configurable series target from Oscar Grind settings and control dialogs

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*
- `python -m py_compile strategies/oscar_grind_2.py strategies/oscar_grind_1.py gui/settings_oscar_grind.py gui/strategy_control_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_68b558ca5e488322af16235ac7e8c4a8