### PR TITLE
Handle qdarktheme absence or API changes

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -64,9 +64,17 @@ class MainWindow(QWidget):
         font_menu.addAction("Выбрать...", self._choose_font)
         theme_menu = self.menu_bar.addMenu("Тема")
         if qdarktheme:
-            theme_menu.addAction("Светлая", lambda: qdarktheme.setup_theme("light"))
-            theme_menu.addAction("Тёмная", lambda: qdarktheme.setup_theme("dark"))
-            theme_menu.addAction("Системная", lambda: qdarktheme.setup_theme("auto"))
+            def _apply_theme(mode: str) -> None:
+                if hasattr(qdarktheme, "setup_theme"):
+                    qdarktheme.setup_theme(mode)
+                elif hasattr(qdarktheme, "load_stylesheet"):
+                    QApplication.instance().setStyleSheet(
+                        qdarktheme.load_stylesheet(mode)
+                    )
+
+            theme_menu.addAction("Светлая", lambda: _apply_theme("light"))
+            theme_menu.addAction("Тёмная", lambda: _apply_theme("dark"))
+            theme_menu.addAction("Системная", lambda: _apply_theme("auto"))
         else:
             theme_menu.setEnabled(False)
 

--- a/main.py
+++ b/main.py
@@ -18,7 +18,10 @@ def run_gui():
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
     if qdarktheme:
-        qdarktheme.setup_theme("auto")
+        if hasattr(qdarktheme, "setup_theme"):
+            qdarktheme.setup_theme("auto")
+        elif hasattr(qdarktheme, "load_stylesheet"):
+            app.setStyleSheet(qdarktheme.load_stylesheet("auto"))
     font = QFont("Calibri", 10)
     app.setFont(font)
 


### PR DESCRIPTION
## Summary
- Avoid crashing when qdarktheme lacks `setup_theme`
- Support applying themes via `load_stylesheet` if available

## Testing
- `pip install qdarktheme` *(fails: Could not find a version that satisfies the requirement qdarktheme)*
- `make run` *(fails: ModuleNotFoundError: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_68b55cd71e0c8322a184e04b919e7e6c