### PR TITLE
Persist theme selection and support system theme

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,5 +4,6 @@
     "domain": "intrade27.bar",
     "ws_url": "ws://192.168.56.101:8080",
     "font_family": "Ubuntu",
-    "font_size": 11
+    "font_size": 11,
+    "theme": "system"
 }

--- a/core/config.py
+++ b/core/config.py
@@ -25,6 +25,9 @@ try:
 except ValueError:
     FONT_SIZE = None
 
+# Тема оформления приложения: "light", "dark" или "system"
+THEME: str = os.getenv("THEME", "system")
+
 
 def _read_json(path: str) -> Dict[str, Any]:
     if not os.path.exists(path):
@@ -54,7 +57,7 @@ def load_config() -> None:
       3) Значения по умолчанию
     Если файла нет — он будет создан с текущими значениями (дефолты/окружение).
     """
-    global APP_NAME, APP_VERSION, domain, base_url, ws_url, FONT_FAMILY, FONT_SIZE
+    global APP_NAME, APP_VERSION, domain, base_url, ws_url, FONT_FAMILY, FONT_SIZE, THEME
 
     if not os.path.exists(_CONFIG_FILE):
         # создаём файл с текущими (дефолт/окружение) значениями
@@ -84,6 +87,9 @@ def load_config() -> None:
         except (TypeError, ValueError):
             pass
 
+    if "THEME" not in os.environ:
+        THEME = data.get("theme", THEME)
+
     base_url = f"https://{domain}"
 
 
@@ -101,6 +107,7 @@ def save_config() -> None:
             "ws_url": ws_url,
             "font_family": FONT_FAMILY,
             "font_size": FONT_SIZE,
+            "theme": THEME,
         }
     )
     _write_json(_CONFIG_FILE, data)
@@ -142,6 +149,10 @@ def get_font_size() -> int | None:
     return FONT_SIZE
 
 
+def get_theme() -> str:
+    return THEME
+
+
 # ===== Опционально: апдейтеры из кода =====
 def set_app_name(name: str) -> None:
     global APP_NAME
@@ -161,3 +172,8 @@ def set_font_family(name: str | None) -> None:
 def set_font_size(size: int | None) -> None:
     global FONT_SIZE
     FONT_SIZE = size
+
+
+def set_theme(theme: str) -> None:
+    global THEME
+    THEME = theme

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -65,16 +65,21 @@ class MainWindow(QWidget):
         theme_menu = self.menu_bar.addMenu("Тема")
         if qdarktheme:
             def _apply_theme(mode: str) -> None:
-                if hasattr(qdarktheme, "setup_theme"):
-                    qdarktheme.setup_theme(mode)
-                elif hasattr(qdarktheme, "load_stylesheet"):
-                    QApplication.instance().setStyleSheet(
-                        qdarktheme.load_stylesheet(mode)
-                    )
+                app = QApplication.instance()
+                if mode in ("light", "dark"):
+                    if hasattr(qdarktheme, "setup_theme"):
+                        qdarktheme.setup_theme(mode)
+                    elif hasattr(qdarktheme, "load_stylesheet"):
+                        app.setStyleSheet(qdarktheme.load_stylesheet(mode))
+                else:
+                    app.setPalette(app.style().standardPalette())
+                    app.setStyleSheet("")
+                config.set_theme(mode)
+                config.save_config()
 
             theme_menu.addAction("Светлая", lambda: _apply_theme("light"))
             theme_menu.addAction("Тёмная", lambda: _apply_theme("dark"))
-            theme_menu.addAction("Системная", lambda: _apply_theme("auto"))
+            theme_menu.addAction("Системная", lambda: _apply_theme("system"))
         else:
             theme_menu.setEnabled(False)
 

--- a/main.py
+++ b/main.py
@@ -17,11 +17,15 @@ from core import config
 def run_gui():
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
-    if qdarktheme:
+    theme = config.get_theme()
+    if qdarktheme and theme in ("light", "dark"):
         if hasattr(qdarktheme, "setup_theme"):
-            qdarktheme.setup_theme("auto")
+            qdarktheme.setup_theme(theme)
         elif hasattr(qdarktheme, "load_stylesheet"):
-            app.setStyleSheet(qdarktheme.load_stylesheet("auto"))
+            app.setStyleSheet(qdarktheme.load_stylesheet(theme))
+    else:
+        app.setPalette(app.style().standardPalette())
+        app.setStyleSheet("")
     font = QFont("Calibri", 10)
     app.setFont(font)
 


### PR DESCRIPTION
## Summary
- Allow choosing light, dark or system themes and save selection in config
- Apply stored theme on startup and reset palette when using system theme

## Testing
- `python -m py_compile main.py core/config.py gui/main_window.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b561d143f08322a90d83d3955ce2dc