### PR TITLE
feat: add strategy templates

### DIFF
--- a/core/templates.py
+++ b/core/templates.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+from typing import List, Dict
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+
+
+def load_templates(strategy_key: str) -> List[Dict]:
+    """Load list of templates for a given strategy."""
+    path = TEMPLATES_DIR / f"{strategy_key}.json"
+    if not path.exists():
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            return data
+    except Exception:
+        pass
+    return []
+
+
+def save_templates(strategy_key: str, templates: List[Dict]) -> None:
+    """Persist templates for a strategy."""
+    path = TEMPLATES_DIR / f"{strategy_key}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(templates, f, ensure_ascii=False, indent=2)

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -31,6 +31,7 @@ from core import config
 from gui.bot_add_dialog import AddBotDialog, ALL_SYMBOLS_LABEL
 from gui.risk_dialog import RiskDialog
 from gui.trades_table_widget import TradesTableWidget
+from gui.templates_dialog import TemplatesDialog
 from core.session import (
     create_http_client_from_browser_cookies,
     refresh_http_client_cookies,
@@ -82,6 +83,9 @@ class MainWindow(QWidget):
             theme_menu.addAction("Системная", lambda: _apply_theme("system"))
         else:
             theme_menu.setEnabled(False)
+
+        # Управление шаблонами стратегий
+        self.menu_bar.addAction("Шаблоны стратегий", self._open_templates_dialog)
 
         # === имя/версия приложения ===
         try:
@@ -342,6 +346,10 @@ class MainWindow(QWidget):
         config.set_font_family(font.family())
         config.set_font_size(font.pointSize())
         config.save_config()
+
+    def _open_templates_dialog(self):
+        dlg = TemplatesDialog(self)
+        dlg.exec()
 
     # -------------------- bots --------------------
     def show_add_bot_dialog(self):

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -17,6 +17,7 @@ from PyQt6.QtWidgets import (
     QHeaderView,
     QComboBox,
     QCheckBox,
+    QInputDialog,
 )
 from PyQt6.QtGui import QColor, QBrush
 from PyQt6.QtCore import QTimer, Qt
@@ -26,6 +27,7 @@ from core.policy import normalize_sprint
 from core.money import format_money
 from core.logger import ts
 from gui.bot_add_dialog import ALL_TF_LABEL
+from core.templates import load_templates, save_templates
 
 
 class StrategyControlDialog(QDialog):
@@ -248,12 +250,27 @@ class StrategyControlDialog(QDialog):
         self.trade_type.currentTextChanged.connect(_update_minutes_enabled)
         _update_minutes_enabled(self.trade_type.currentText())
 
-        # Кнопка «Сохранить настройки»
+        # ---- шаблоны ----
+        self.templates = load_templates(self.strategy_key)
+        template_row = QWidget()
+        th = QHBoxLayout(template_row)
+        self.template_combo = QComboBox()
+        for tmpl in self.templates:
+            self.template_combo.addItem(str(tmpl.get("name", "")))
+        self.btn_apply_template = QPushButton("Применить")
+        self.btn_apply_template.clicked.connect(self.apply_template)
+        th.addWidget(self.template_combo, 1)
+        th.addWidget(self.btn_apply_template)
+
+        # Кнопки сохранения/шаблонов
         settings_row = QWidget()
         sh = QHBoxLayout(settings_row)
-        self.btn_save_settings = QPushButton("💾 Сохранить настройки")
-        self.btn_save_settings.clicked.connect(self.save_settings)
+        self.btn_save_template = QPushButton("💾 Сохранить как шаблон")
+        self.btn_save_template.clicked.connect(self.save_template)
+        self.btn_save_settings = QPushButton("💾 Применить настройки")
+        self.btn_save_settings.clicked.connect(self.apply_settings)
         sh.addStretch(1)
+        sh.addWidget(self.btn_save_template)
         sh.addWidget(self.btn_save_settings)
 
         # ---------- Controls ----------
@@ -278,6 +295,7 @@ class StrategyControlDialog(QDialog):
         lv.setContentsMargins(0, 0, 0, 0)
         lv.setSpacing(8)
         lv.addWidget(self.log_edit, 1)
+        lv.addWidget(template_row)
         lv.addWidget(self.settings_box)
         lv.addWidget(settings_row)
         lv.addWidget(controls)
@@ -390,12 +408,12 @@ class StrategyControlDialog(QDialog):
             self.log_edit.append(ts(f"⚠ Ошибка удаления: {e}"))
 
     # ---- сохранение настроек ----
-    def save_settings(self):
+    def _collect_params(self):
         symbol = str(self.bot.strategy_kwargs.get("symbol", ""))
         trade_type = self.trade_type.currentText()
-        m = int(self.minutes.value())
+        m = int(self.minutes.value()) if self.minutes else 0
         norm = m
-        if trade_type != "classic":
+        if trade_type != "classic" and self.minutes is not None:
             norm = normalize_sprint(symbol, m)
             if norm is None:
                 box = QMessageBox(self)
@@ -408,7 +426,7 @@ class StrategyControlDialog(QDialog):
                         "Для выбранной пары разрешено 1 или 3–500 минут (2 минуты — нельзя)."
                     )
                 box.open()
-                return
+                return None
 
         if getattr(self, "strategy_key", "") in ("oscar_grind_1", "oscar_grind_2"):
             new_params = {
@@ -419,7 +437,7 @@ class StrategyControlDialog(QDialog):
                 "min_percent": self.min_percent.value(),
                 "double_entry": bool(self.double_entry.isChecked()),
             }
-            if trade_type != "classic":
+            if trade_type != "classic" and self.minutes is not None:
                 new_params["minutes"] = int(norm)
         elif getattr(self, "strategy_key", "") == "fixed":
             new_params = {
@@ -428,7 +446,7 @@ class StrategyControlDialog(QDialog):
                 "min_balance": self.min_balance.value(),
                 "min_percent": self.min_percent.value(),
             }
-            if trade_type != "classic":
+            if trade_type != "classic" and self.minutes is not None:
                 new_params["minutes"] = int(norm)
         else:
             new_params = {
@@ -439,16 +457,22 @@ class StrategyControlDialog(QDialog):
                 "coefficient": round(float(self.coefficient.value()), 2),
                 "min_percent": self.min_percent.value(),
             }
-            if trade_type != "classic":
+            if trade_type != "classic" and self.minutes is not None:
                 new_params["minutes"] = int(norm)
         new_params["trade_type"] = trade_type
+        return new_params
+
+    def apply_settings(self):
+        new_params = self._collect_params()
+        if new_params is None:
+            return
 
         self.bot.strategy_kwargs.setdefault("params", {}).update(new_params)
         if self.bot.strategy and hasattr(self.bot.strategy, "update_params"):
             self.bot.strategy.update_params(**new_params)
 
-        if trade_type != "classic":
-            self.minutes.setValue(int(norm))
+        if new_params.get("minutes") and self.minutes is not None:
+            self.minutes.setValue(int(new_params["minutes"]))
 
         formatted = []
         for k, v in new_params.items():
@@ -459,6 +483,61 @@ class StrategyControlDialog(QDialog):
         self.log_edit.append(
             ts("💾 Настройки сохранены: {" + ", ".join(formatted) + "}")
         )
+
+    def save_template(self):
+        new_params = self._collect_params()
+        if new_params is None:
+            return
+        templates = load_templates(self.strategy_key)
+        default_name = f"Шаблон {len(templates) + 1}"
+        name, ok = QInputDialog.getText(
+            self, "Сохранить как шаблон", "Название шаблона:", text=default_name
+        )
+        if not ok or not name:
+            return
+        replaced = False
+        for tmpl in templates:
+            if tmpl.get("name") == name:
+                tmpl["params"] = new_params
+                replaced = True
+                break
+        if not replaced:
+            templates.append({"name": name, "params": new_params})
+        save_templates(self.strategy_key, templates)
+        self.templates = templates
+        self.template_combo.clear()
+        for tmpl in self.templates:
+            self.template_combo.addItem(str(tmpl.get("name", "")))
+        idx = self.template_combo.findText(name)
+        if idx >= 0:
+            self.template_combo.setCurrentIndex(idx)
+
+    def apply_template(self):
+        idx = self.template_combo.currentIndex()
+        if idx < 0:
+            return
+        tmpl = self.templates[idx]
+        params = tmpl.get("params", {})
+        for k, v in params.items():
+            if k == "trade_type":
+                self.trade_type.setCurrentText(str(v))
+            elif k == "minutes" and self.minutes is not None:
+                self.minutes.setValue(int(v))
+            elif k == "base_investment" and hasattr(self, "base_investment"):
+                self.base_investment.setValue(int(v))
+            elif k == "max_steps" and hasattr(self, "max_steps"):
+                self.max_steps.setValue(int(v))
+            elif k == "repeat_count" and hasattr(self, "repeat_count"):
+                self.repeat_count.setValue(int(v))
+            elif k == "min_balance" and hasattr(self, "min_balance"):
+                self.min_balance.setValue(int(v))
+            elif k == "coefficient" and hasattr(self, "coefficient"):
+                self.coefficient.setValue(float(v))
+            elif k == "min_percent" and hasattr(self, "min_percent"):
+                self.min_percent.setValue(int(v))
+            elif k == "double_entry" and hasattr(self, "double_entry"):
+                self.double_entry.setChecked(bool(v))
+        self.apply_settings()
 
     # ---- хелперы: локальная таблица сделок ----
     def _fmt_money(self, value: float, ccy: str) -> str:

--- a/gui/templates_dialog.py
+++ b/gui/templates_dialog.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from PyQt6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QComboBox,
+    QListWidget,
+    QPushButton,
+    QWidget,
+    QInputDialog,
+)
+from typing import List, Dict
+
+from core.templates import load_templates, save_templates
+
+
+class TemplatesDialog(QDialog):
+    """Dialog for managing strategy templates."""
+
+    def __init__(self, main_window):
+        super().__init__(main_window)
+        self.main = main_window
+        self.setWindowTitle("Шаблоны стратегий")
+
+        layout = QVBoxLayout(self)
+
+        self.strategy_combo = QComboBox(self)
+        self.strategy_combo.addItems(list(self.main.strategy_labels.keys()))
+        self.strategy_combo.currentTextChanged.connect(self._load_templates)
+        layout.addWidget(self.strategy_combo)
+
+        self.list_widget = QListWidget(self)
+        layout.addWidget(self.list_widget, 1)
+
+        btn_row = QWidget(self)
+        bh = QHBoxLayout(btn_row)
+        self.btn_add = QPushButton("Добавить", self)
+        self.btn_rename = QPushButton("Переименовать", self)
+        self.btn_delete = QPushButton("Удалить", self)
+        self.btn_up = QPushButton("Вверх", self)
+        self.btn_down = QPushButton("Вниз", self)
+        for b in (self.btn_add, self.btn_rename, self.btn_delete, self.btn_up, self.btn_down):
+            bh.addWidget(b)
+        layout.addWidget(btn_row)
+
+        self.btn_add.clicked.connect(self._add_template)
+        self.btn_rename.clicked.connect(self._rename_template)
+        self.btn_delete.clicked.connect(self._delete_template)
+        self.btn_up.clicked.connect(self._move_up)
+        self.btn_down.clicked.connect(self._move_down)
+
+        self.templates: List[Dict] = []
+        self._load_templates(self.strategy_combo.currentText())
+
+    # --- helpers ---
+    def _current_strategy(self) -> str:
+        return self.strategy_combo.currentText()
+
+    def _load_templates(self, strategy_key: str) -> None:
+        self.templates = load_templates(strategy_key)
+        self.list_widget.clear()
+        for tmpl in self.templates:
+            self.list_widget.addItem(str(tmpl.get("name", "")))
+
+    def _save(self) -> None:
+        save_templates(self._current_strategy(), self.templates)
+
+    def _default_name(self) -> str:
+        return f"Шаблон {len(self.templates) + 1}"
+
+    def _add_template(self) -> None:
+        name, ok = QInputDialog.getText(self, "Новый шаблон", "Название:", text=self._default_name())
+        if ok and name:
+            self.templates.append({"name": name, "params": {}})
+            self._save()
+            self._load_templates(self._current_strategy())
+
+    def _rename_template(self) -> None:
+        row = self.list_widget.currentRow()
+        if row < 0:
+            return
+        tmpl = self.templates[row]
+        name, ok = QInputDialog.getText(self, "Переименовать", "Новое название:", text=tmpl.get("name", ""))
+        if ok and name:
+            tmpl["name"] = name
+            self._save()
+            self._load_templates(self._current_strategy())
+            self.list_widget.setCurrentRow(row)
+
+    def _delete_template(self) -> None:
+        row = self.list_widget.currentRow()
+        if row < 0:
+            return
+        del self.templates[row]
+        self._save()
+        self._load_templates(self._current_strategy())
+
+    def _move_up(self) -> None:
+        row = self.list_widget.currentRow()
+        if row <= 0:
+            return
+        self.templates[row - 1], self.templates[row] = self.templates[row], self.templates[row - 1]
+        self._save()
+        self._load_templates(self._current_strategy())
+        self.list_widget.setCurrentRow(row - 1)
+
+    def _move_down(self) -> None:
+        row = self.list_widget.currentRow()
+        if row < 0 or row >= len(self.templates) - 1:
+            return
+        self.templates[row + 1], self.templates[row] = self.templates[row], self.templates[row + 1]
+        self._save()
+        self._load_templates(self._current_strategy())
+        self.list_widget.setCurrentRow(row + 1)


### PR DESCRIPTION
## Summary
- add JSON-based storage for strategy templates
- manage templates in new GUI dialog
- allow saving/applying templates from strategy control

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b67eb11e3c832283306887a5c3b46f