### PR TITLE
Enhance strategy template editing and control layout

### DIFF
--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -108,7 +108,8 @@ class StrategyControlDialog(QDialog):
 
         # ---------- Настройки (inline) ----------
         self.settings_box = QGroupBox("Настройки стратегии")
-        form = QFormLayout(self.settings_box)
+        box_v = QVBoxLayout(self.settings_box)
+        form = QFormLayout()
 
         params = {}
         if self.bot.strategy and getattr(self.bot.strategy, "params", None):
@@ -138,6 +139,19 @@ class StrategyControlDialog(QDialog):
         strategy_key = str(self.bot.strategy_kwargs.get("strategy_key", "")).lower()
         self.strategy_key = strategy_key
         self.minutes = None
+
+        # ---- шаблоны ----
+        self.templates = load_templates(self.strategy_key)
+        template_row = QWidget()
+        th = QHBoxLayout(template_row)
+        self.template_combo = QComboBox()
+        for tmpl in self.templates:
+            self.template_combo.addItem(str(tmpl.get("name", "")))
+        self.btn_apply_template = QPushButton("Применить")
+        self.btn_apply_template.clicked.connect(self.apply_template)
+        th.addWidget(self.template_combo, 1)
+        th.addWidget(self.btn_apply_template)
+        box_v.addWidget(template_row)
 
         if strategy_key in ("oscar_grind_1", "oscar_grind_2"):
             self.minutes = QSpinBox()
@@ -250,27 +264,24 @@ class StrategyControlDialog(QDialog):
         self.trade_type.currentTextChanged.connect(_update_minutes_enabled)
         _update_minutes_enabled(self.trade_type.currentText())
 
-        # ---- шаблоны ----
-        self.templates = load_templates(self.strategy_key)
-        template_row = QWidget()
-        th = QHBoxLayout(template_row)
-        self.template_combo = QComboBox()
-        for tmpl in self.templates:
-            self.template_combo.addItem(str(tmpl.get("name", "")))
-        self.btn_apply_template = QPushButton("Применить")
-        self.btn_apply_template.clicked.connect(self.apply_template)
-        th.addWidget(self.template_combo, 1)
-        th.addWidget(self.btn_apply_template)
+        # добавить форму после строки шаблонов
+        box_v.addLayout(form)
 
-        # Кнопки сохранения/шаблонов
-        settings_row = QWidget()
-        sh = QHBoxLayout(settings_row)
+        # кнопка сохранения шаблона внутри groupbox
+        tmpl_btn_row = QWidget()
+        tbh = QHBoxLayout(tmpl_btn_row)
+        tbh.addStretch(1)
         self.btn_save_template = QPushButton("💾 Сохранить как шаблон")
         self.btn_save_template.clicked.connect(self.save_template)
+        tbh.addWidget(self.btn_save_template)
+        box_v.addWidget(tmpl_btn_row)
+
+        # Кнопка применения настроек (снаружи)
+        settings_row = QWidget()
+        sh = QHBoxLayout(settings_row)
         self.btn_save_settings = QPushButton("💾 Применить настройки")
         self.btn_save_settings.clicked.connect(self.apply_settings)
         sh.addStretch(1)
-        sh.addWidget(self.btn_save_template)
         sh.addWidget(self.btn_save_settings)
 
         # ---------- Controls ----------
@@ -295,7 +306,6 @@ class StrategyControlDialog(QDialog):
         lv.setContentsMargins(0, 0, 0, 0)
         lv.setSpacing(8)
         lv.addWidget(self.log_edit, 1)
-        lv.addWidget(template_row)
         lv.addWidget(self.settings_box)
         lv.addWidget(settings_row)
         lv.addWidget(controls)
@@ -481,7 +491,7 @@ class StrategyControlDialog(QDialog):
             else:
                 formatted.append(f"'{k}': {v}")
         self.log_edit.append(
-            ts("💾 Настройки сохранены: {" + ", ".join(formatted) + "}")
+            ts("💾 Настройки применены: {" + ", ".join(formatted) + "}")
         )
 
     def save_template(self):

--- a/gui/templates_dialog.py
+++ b/gui/templates_dialog.py
@@ -13,6 +13,7 @@ from PyQt6.QtWidgets import (
 from typing import List, Dict
 
 from core.templates import load_templates, save_templates
+from gui.settings_factory import get_settings_dialog_cls
 
 
 class TemplatesDialog(QDialog):
@@ -38,15 +39,24 @@ class TemplatesDialog(QDialog):
         self.btn_add = QPushButton("Добавить", self)
         self.btn_rename = QPushButton("Переименовать", self)
         self.btn_delete = QPushButton("Удалить", self)
+        self.btn_edit = QPushButton("Настройки", self)
         self.btn_up = QPushButton("Вверх", self)
         self.btn_down = QPushButton("Вниз", self)
-        for b in (self.btn_add, self.btn_rename, self.btn_delete, self.btn_up, self.btn_down):
+        for b in (
+            self.btn_add,
+            self.btn_rename,
+            self.btn_delete,
+            self.btn_edit,
+            self.btn_up,
+            self.btn_down,
+        ):
             bh.addWidget(b)
         layout.addWidget(btn_row)
 
         self.btn_add.clicked.connect(self._add_template)
         self.btn_rename.clicked.connect(self._rename_template)
         self.btn_delete.clicked.connect(self._delete_template)
+        self.btn_edit.clicked.connect(self._edit_template)
         self.btn_up.clicked.connect(self._move_up)
         self.btn_down.clicked.connect(self._move_down)
 
@@ -69,10 +79,30 @@ class TemplatesDialog(QDialog):
     def _default_name(self) -> str:
         return f"Шаблон {len(self.templates) + 1}"
 
+    def _edit_params(self, params: Dict) -> Dict | None:
+        """Open settings dialog for current strategy and return params or None."""
+        strategy_key = self._current_strategy()
+        strategy_cls = self.main.available_strategies.get(strategy_key)
+        dlg_cls = get_settings_dialog_cls(strategy_cls) if strategy_cls else None
+        if not dlg_cls:
+            return params
+        params = dict(params)
+        params.setdefault("timeframe", "M1")
+        params.setdefault("symbol", "")
+        dlg = dlg_cls(params, parent=self)
+        if dlg.exec():
+            return dlg.get_params()
+        return None
+
     def _add_template(self) -> None:
-        name, ok = QInputDialog.getText(self, "Новый шаблон", "Название:", text=self._default_name())
+        name, ok = QInputDialog.getText(
+            self, "Новый шаблон", "Название:", text=self._default_name()
+        )
         if ok and name:
-            self.templates.append({"name": name, "params": {}})
+            params = self._edit_params({})
+            if params is None:
+                return
+            self.templates.append({"name": name, "params": params})
             self._save()
             self._load_templates(self._current_strategy())
 
@@ -87,6 +117,20 @@ class TemplatesDialog(QDialog):
             self._save()
             self._load_templates(self._current_strategy())
             self.list_widget.setCurrentRow(row)
+
+    def _edit_template(self) -> None:
+        row = self.list_widget.currentRow()
+        if row < 0:
+            return
+        tmpl = self.templates[row]
+        params = tmpl.get("params", {})
+        new_params = self._edit_params(params)
+        if new_params is None:
+            return
+        tmpl["params"] = new_params
+        self._save()
+        self._load_templates(self._current_strategy())
+        self.list_widget.setCurrentRow(row)
 
     def _delete_template(self) -> None:
         row = self.list_widget.currentRow()


### PR DESCRIPTION
## Summary
- allow editing of strategy template parameters and require settings on creation
- move template controls and save button inside strategy settings box
- log "Настройки применены" when applying settings

## Testing
- `python -m py_compile gui/templates_dialog.py gui/strategy_control_dialog.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b681ce6ea08322b2d7b9b651b28a31