### PR TITLE
feat: remember last template and update ui

### DIFF
--- a/core/templates.py
+++ b/core/templates.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import List, Dict
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+LAST_USED_FILE = TEMPLATES_DIR / "last_used.json"
 
 
 def load_templates(strategy_key: str) -> List[Dict]:
@@ -26,3 +27,34 @@ def save_templates(strategy_key: str, templates: List[Dict]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         json.dump(templates, f, ensure_ascii=False, indent=2)
+
+
+def load_last_template(strategy_key: str) -> str | None:
+    """Return name of last used template for strategy or None."""
+    if not LAST_USED_FILE.exists():
+        return None
+    try:
+        with open(LAST_USED_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data.get(strategy_key)
+    except Exception:
+        return None
+    return None
+
+
+def save_last_template(strategy_key: str, name: str) -> None:
+    """Persist last used template name for strategy."""
+    data: Dict[str, str] = {}
+    if LAST_USED_FILE.exists():
+        try:
+            with open(LAST_USED_FILE, "r", encoding="utf-8") as f:
+                obj = json.load(f)
+            if isinstance(obj, dict):
+                data = obj
+        except Exception:
+            pass
+    data[strategy_key] = name
+    LAST_USED_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(LAST_USED_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -27,7 +27,12 @@ from core.policy import normalize_sprint
 from core.money import format_money
 from core.logger import ts
 from gui.bot_add_dialog import ALL_TF_LABEL
-from core.templates import load_templates, save_templates
+from core.templates import (
+    load_templates,
+    save_templates,
+    load_last_template,
+    save_last_template,
+)
 
 
 class StrategyControlDialog(QDialog):
@@ -276,17 +281,11 @@ class StrategyControlDialog(QDialog):
         tbh.addWidget(self.btn_save_template)
         box_v.addWidget(tmpl_btn_row)
 
-        # Кнопка применения настроек (снаружи)
-        settings_row = QWidget()
-        sh = QHBoxLayout(settings_row)
-        self.btn_save_settings = QPushButton("💾 Применить настройки")
-        self.btn_save_settings.clicked.connect(self.apply_settings)
-        sh.addStretch(1)
-        sh.addWidget(self.btn_save_settings)
-
         # ---------- Controls ----------
         controls = QWidget()
         ch = QHBoxLayout(controls)
+        self.btn_save_settings = QPushButton("💾 Применить настройки")
+        self.btn_save_settings.clicked.connect(self.apply_settings)
         self.btn_toggle = QPushButton("🚀 Старт")
         self.btn_stop = QPushButton("⏹ Стоп")
         self.btn_delete = QPushButton("× Удалить")
@@ -296,6 +295,7 @@ class StrategyControlDialog(QDialog):
         self.btn_delete.clicked.connect(self._do_delete)
 
         ch.addStretch(1)
+        ch.addWidget(self.btn_save_settings)
         ch.addWidget(self.btn_toggle)
         ch.addWidget(self.btn_stop)
         ch.addWidget(self.btn_delete)
@@ -307,7 +307,6 @@ class StrategyControlDialog(QDialog):
         lv.setSpacing(8)
         lv.addWidget(self.log_edit, 1)
         lv.addWidget(self.settings_box)
-        lv.addWidget(settings_row)
         lv.addWidget(controls)
 
         top_split = QWidget()
@@ -328,6 +327,14 @@ class StrategyControlDialog(QDialog):
         self.timer.setInterval(200)
         self.timer.timeout.connect(self._refresh_status_and_buttons)
         self.timer.start()
+
+        last_name = load_last_template(self.strategy_key)
+        if last_name:
+            idx = self.template_combo.findText(str(last_name))
+            if idx >= 0:
+                self.template_combo.setCurrentIndex(idx)
+                self.apply_template()
+
         self._refresh_status_and_buttons()
 
         # === Подписка на сделки для КОНКРЕТНОГО бота ===
@@ -521,6 +528,7 @@ class StrategyControlDialog(QDialog):
         idx = self.template_combo.findText(name)
         if idx >= 0:
             self.template_combo.setCurrentIndex(idx)
+            save_last_template(self.strategy_key, name)
 
     def apply_template(self):
         idx = self.template_combo.currentIndex()
@@ -548,6 +556,7 @@ class StrategyControlDialog(QDialog):
             elif k == "double_entry" and hasattr(self, "double_entry"):
                 self.double_entry.setChecked(bool(v))
         self.apply_settings()
+        save_last_template(self.strategy_key, str(tmpl.get("name", "")))
 
     # ---- хелперы: локальная таблица сделок ----
     def _fmt_money(self, value: float, ccy: str) -> str:

--- a/gui/templates_dialog.py
+++ b/gui/templates_dialog.py
@@ -4,12 +4,14 @@ from PyQt6.QtWidgets import (
     QDialog,
     QVBoxLayout,
     QHBoxLayout,
-    QComboBox,
     QListWidget,
+    QListWidgetItem,
     QPushButton,
     QWidget,
     QInputDialog,
+    QDialogButtonBox,
 )
+from PyQt6.QtCore import Qt
 from typing import List, Dict
 
 from core.templates import load_templates, save_templates
@@ -24,54 +26,78 @@ class TemplatesDialog(QDialog):
         self.main = main_window
         self.setWindowTitle("Шаблоны стратегий")
 
-        layout = QVBoxLayout(self)
+        layout = QHBoxLayout(self)
 
-        self.strategy_combo = QComboBox(self)
-        self.strategy_combo.addItems(list(self.main.strategy_labels.keys()))
-        self.strategy_combo.currentTextChanged.connect(self._load_templates)
-        layout.addWidget(self.strategy_combo)
+        # список стратегий слева
+        self.strategy_list = QListWidget(self)
+        for key, label in self.main.strategy_labels.items():
+            item = QListWidgetItem(label)
+            item.setData(Qt.ItemDataRole.UserRole, key)
+            self.strategy_list.addItem(item)
+        self.strategy_list.currentRowChanged.connect(self._on_strategy_change)
+        layout.addWidget(self.strategy_list)
 
+        # средняя колонка: шаблоны + кнопки
+        tmpl_column = QVBoxLayout()
         self.list_widget = QListWidget(self)
-        layout.addWidget(self.list_widget, 1)
+        self.list_widget.currentRowChanged.connect(self._show_template_settings)
+        tmpl_column.addWidget(self.list_widget, 1)
 
         btn_row = QWidget(self)
         bh = QHBoxLayout(btn_row)
         self.btn_add = QPushButton("Добавить", self)
         self.btn_rename = QPushButton("Переименовать", self)
         self.btn_delete = QPushButton("Удалить", self)
-        self.btn_edit = QPushButton("Настройки", self)
+        self.btn_save = QPushButton("Сохранить", self)
         self.btn_up = QPushButton("Вверх", self)
         self.btn_down = QPushButton("Вниз", self)
         for b in (
             self.btn_add,
             self.btn_rename,
             self.btn_delete,
-            self.btn_edit,
+            self.btn_save,
             self.btn_up,
             self.btn_down,
         ):
             bh.addWidget(b)
-        layout.addWidget(btn_row)
+        tmpl_column.addWidget(btn_row)
+        layout.addLayout(tmpl_column)
+
+        # правая область: настройки выбранного шаблона
+        self.settings_container = QWidget(self)
+        self.settings_layout = QVBoxLayout(self.settings_container)
+        layout.addWidget(self.settings_container, 1)
 
         self.btn_add.clicked.connect(self._add_template)
         self.btn_rename.clicked.connect(self._rename_template)
         self.btn_delete.clicked.connect(self._delete_template)
-        self.btn_edit.clicked.connect(self._edit_template)
+        self.btn_save.clicked.connect(self._save_current_settings)
         self.btn_up.clicked.connect(self._move_up)
         self.btn_down.clicked.connect(self._move_down)
 
         self.templates: List[Dict] = []
-        self._load_templates(self.strategy_combo.currentText())
+        self.current_settings_widget = None
+        self.strategy_list.setCurrentRow(0)
 
     # --- helpers ---
     def _current_strategy(self) -> str:
-        return self.strategy_combo.currentText()
+        item = self.strategy_list.currentItem()
+        if item:
+            return item.data(Qt.ItemDataRole.UserRole)
+        return ""
+
+    def _on_strategy_change(self, *_):
+        self._load_templates(self._current_strategy())
 
     def _load_templates(self, strategy_key: str) -> None:
         self.templates = load_templates(strategy_key)
         self.list_widget.clear()
         for tmpl in self.templates:
             self.list_widget.addItem(str(tmpl.get("name", "")))
+        if self.templates:
+            self.list_widget.setCurrentRow(0)
+        else:
+            self._show_template_settings(-1)
 
     def _save(self) -> None:
         save_templates(self._current_strategy(), self.templates)
@@ -79,58 +105,63 @@ class TemplatesDialog(QDialog):
     def _default_name(self) -> str:
         return f"Шаблон {len(self.templates) + 1}"
 
-    def _edit_params(self, params: Dict) -> Dict | None:
-        """Open settings dialog for current strategy and return params or None."""
+    def _show_template_settings(self, row: int) -> None:
+        while self.settings_layout.count():
+            item = self.settings_layout.takeAt(0)
+            w = item.widget()
+            if w:
+                w.deleteLater()
+        self.current_settings_widget = None
+        if row < 0 or row >= len(self.templates):
+            return
+        tmpl = self.templates[row]
+        params = tmpl.get("params", {})
         strategy_key = self._current_strategy()
         strategy_cls = self.main.available_strategies.get(strategy_key)
         dlg_cls = get_settings_dialog_cls(strategy_cls) if strategy_cls else None
         if not dlg_cls:
-            return params
+            return
         params = dict(params)
         params.setdefault("timeframe", "M1")
         params.setdefault("symbol", "")
-        dlg = dlg_cls(params, parent=self)
-        if dlg.exec():
-            return dlg.get_params()
-        return None
+        widget = dlg_cls(params, parent=self)
+        btn_box = widget.findChild(QDialogButtonBox)
+        if btn_box:
+            btn_box.setVisible(False)
+        self.settings_layout.addWidget(widget)
+        self.current_settings_widget = widget
+
+    def _save_current_settings(self) -> None:
+        row = self.list_widget.currentRow()
+        if row < 0 or self.current_settings_widget is None:
+            return
+        params = self.current_settings_widget.get_params()
+        self.templates[row]["params"] = params
+        self._save()
 
     def _add_template(self) -> None:
         name, ok = QInputDialog.getText(
             self, "Новый шаблон", "Название:", text=self._default_name()
         )
         if ok and name:
-            params = self._edit_params({})
-            if params is None:
-                return
-            self.templates.append({"name": name, "params": params})
+            self.templates.append({"name": name, "params": {}})
             self._save()
             self._load_templates(self._current_strategy())
+            self.list_widget.setCurrentRow(len(self.templates) - 1)
 
     def _rename_template(self) -> None:
         row = self.list_widget.currentRow()
         if row < 0:
             return
         tmpl = self.templates[row]
-        name, ok = QInputDialog.getText(self, "Переименовать", "Новое название:", text=tmpl.get("name", ""))
+        name, ok = QInputDialog.getText(
+            self, "Переименовать", "Новое название:", text=tmpl.get("name", "")
+        )
         if ok and name:
             tmpl["name"] = name
             self._save()
             self._load_templates(self._current_strategy())
             self.list_widget.setCurrentRow(row)
-
-    def _edit_template(self) -> None:
-        row = self.list_widget.currentRow()
-        if row < 0:
-            return
-        tmpl = self.templates[row]
-        params = tmpl.get("params", {})
-        new_params = self._edit_params(params)
-        if new_params is None:
-            return
-        tmpl["params"] = new_params
-        self._save()
-        self._load_templates(self._current_strategy())
-        self.list_widget.setCurrentRow(row)
 
     def _delete_template(self) -> None:
         row = self.list_widget.currentRow()
@@ -144,7 +175,10 @@ class TemplatesDialog(QDialog):
         row = self.list_widget.currentRow()
         if row <= 0:
             return
-        self.templates[row - 1], self.templates[row] = self.templates[row], self.templates[row - 1]
+        self.templates[row - 1], self.templates[row] = (
+            self.templates[row],
+            self.templates[row - 1],
+        )
         self._save()
         self._load_templates(self._current_strategy())
         self.list_widget.setCurrentRow(row - 1)
@@ -153,7 +187,11 @@ class TemplatesDialog(QDialog):
         row = self.list_widget.currentRow()
         if row < 0 or row >= len(self.templates) - 1:
             return
-        self.templates[row + 1], self.templates[row] = self.templates[row], self.templates[row + 1]
+        self.templates[row + 1], self.templates[row] = (
+            self.templates[row],
+            self.templates[row + 1],
+        )
         self._save()
         self._load_templates(self._current_strategy())
         self.list_widget.setCurrentRow(row + 1)
+


### PR DESCRIPTION
## Summary
- place "Apply settings" button beside "Start" in strategy controls
- remember and auto-select last template for each strategy
- redesign templates dialog with strategy list on the left and inline template settings

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b684b5cd1c832298da90c165367685