### PR TITLE
Align strategy control buttons to top-left

### DIFF
--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -295,10 +295,10 @@ class StrategyControlDialog(QDialog):
         self.btn_stop.clicked.connect(self._do_stop)
         self.btn_delete.clicked.connect(self._do_delete)
 
+        ch.addWidget(self.btn_toggle, alignment=Qt.AlignmentFlag.AlignTop)
+        ch.addWidget(self.btn_stop, alignment=Qt.AlignmentFlag.AlignTop)
+        ch.addWidget(self.btn_delete, alignment=Qt.AlignmentFlag.AlignTop)
         ch.addStretch(1)
-        ch.addWidget(self.btn_toggle)
-        ch.addWidget(self.btn_stop)
-        ch.addWidget(self.btn_delete)
 
         # ---------- Главный блок: слева настройки, справа таблица+лог ----------
         left_panel = QWidget()


### PR DESCRIPTION
## Summary
- Left-align and pin Start/Stop/Delete buttons to the top in the strategy control dialog

## Testing
- `python -m py_compile gui/strategy_control_dialog.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b68ef6d6a88322a5af4b9f9ab9718c