### PR TITLE
Reorder template buttons and refresh control icons

### DIFF
--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -283,7 +283,7 @@ class StrategyControlDialog(QDialog):
         # кнопки сохранения/применения шаблона внутри groupbox
         tmpl_btn_row = QWidget()
         tbh = QHBoxLayout(tmpl_btn_row)
-        self.btn_save_settings = QPushButton("💾 Применить настройки")
+        self.btn_save_settings = QPushButton("✅ Применить настройки")
         self.btn_save_settings.clicked.connect(self.apply_settings)
         self.btn_save_template = QPushButton("💾 Сохранить как шаблон")
         self.btn_save_template.clicked.connect(self.save_template)
@@ -300,7 +300,7 @@ class StrategyControlDialog(QDialog):
         ch = QHBoxLayout(controls)
         self.btn_toggle = QPushButton("🚀 Старт")
         self.btn_stop = QPushButton("⏹ Стоп")
-        self.btn_delete = QPushButton("× Удалить")
+        self.btn_delete = QPushButton("❌ Удалить")
 
         for b in (self.btn_toggle, self.btn_stop, self.btn_delete):
             b.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)

--- a/gui/templates_dialog.py
+++ b/gui/templates_dialog.py
@@ -44,15 +44,15 @@ class TemplatesDialog(QDialog):
         bh = QHBoxLayout(btn_row)
         self.btn_add = QPushButton("Добавить", self)
         self.btn_rename = QPushButton("Переименовать", self)
-        self.btn_delete = QPushButton("Удалить", self)
         self.btn_save = QPushButton("Сохранить", self)
+        self.btn_delete = QPushButton("Удалить", self)
         self.btn_up = QPushButton("Вверх", self)
         self.btn_down = QPushButton("Вниз", self)
         for b in (
             self.btn_add,
             self.btn_rename,
-            self.btn_delete,
             self.btn_save,
+            self.btn_delete,
             self.btn_up,
             self.btn_down,
         ):


### PR DESCRIPTION
## Summary
- Swap Save and Delete button order in strategy templates dialog
- Update strategy control dialog icons: distinct Apply Settings, save template icon preserved, Delete uses ❌

## Testing
- `python -m py_compile gui/templates_dialog.py gui/strategy_control_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_68b901cc60fc832281f98d592fd4cb9b