### PR TITLE
Refactor strategy control window and log outputs

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -482,7 +482,7 @@ class MainWindow(QWidget):
         from gui.strategy_control_dialog import StrategyControlDialog
 
         dlg = StrategyControlDialog(self, bot, parent=self)
-        dlg.exec()
+        dlg.show()
 
     def stop_bot(self, bot):
         bot.stop()

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -1,6 +1,5 @@
 # gui/strategy_control_dialog.py
 from PyQt6.QtWidgets import (
-    QDialog,
     QVBoxLayout,
     QHBoxLayout,
     QLabel,
@@ -36,7 +35,7 @@ from core.templates import (
 )
 
 
-class StrategyControlDialog(QDialog):
+class StrategyControlDialog(QWidget):
     """
     Единое окно: статус + пер-ботовый лог + ВСТРОЕННЫЕ НАСТРОЙКИ + управление
     + СПРАВА таблица сделок этого бота.
@@ -300,7 +299,7 @@ class StrategyControlDialog(QDialog):
         ch = QHBoxLayout(controls)
         self.btn_toggle = QPushButton("🚀 Старт")
         self.btn_stop = QPushButton("⏹ Стоп")
-        self.btn_delete = QPushButton("❌ Удалить")
+        self.btn_delete = QPushButton("❌ Удалить бота")
 
         for b in (self.btn_toggle, self.btn_stop, self.btn_delete):
             b.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -150,7 +150,7 @@ class AntiMartingaleStrategy(StrategyBase):
         try:
             self._anchor_is_demo = await is_demo_account(self.http_client)
             mode_txt = "ДЕМО" if self._anchor_is_demo else "РЕАЛ"
-            log(f"[{self.symbol}] Якорный режим счёта: {mode_txt}")
+            log(f"[{self.symbol}] Режим счёта: {mode_txt}")
         except Exception as e:
             log(f"[{self.symbol}] ⚠ Не удалось определить режим счёта при старте: {e}")
             self._anchor_is_demo = False
@@ -160,7 +160,7 @@ class AntiMartingaleStrategy(StrategyBase):
                 self.http_client, self.user_id, self.user_hash
             )
             log(
-                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}, якорь: {self._anchor_ccy}"
+                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}"
             )
         except Exception as e:
             log(f"[{self.symbol}] ⚠ Не удалось получить баланс при старте: {e}")
@@ -180,7 +180,7 @@ class AntiMartingaleStrategy(StrategyBase):
                 self._last_signal_ver = st.get("version", 0) or 0
                 if self.log:
                     self.log(
-                        f"[{self.symbol}] Заякорена версия сигнала: v{self._last_signal_ver}"
+                        f"[{self.symbol}] Версия сигнала: v{self._last_signal_ver}"
                     )
             else:
                 self._last_signal_ver = 0

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -70,7 +70,7 @@ class FibonacciStrategy(MartingaleStrategy):
         try:
             self._anchor_is_demo = await is_demo_account(self.http_client)
             mode_txt = "ДЕМО" if self._anchor_is_demo else "РЕАЛ"
-            log(f"[{self.symbol}] Якорный режим счёта: {mode_txt}")
+            log(f"[{self.symbol}] Режим счёта: {mode_txt}")
         except Exception as e:  # pragma: no cover - сеть
             log(f"[{self.symbol}] ⚠ Не удалось определить режим счёта при старте: {e}")
             self._anchor_is_demo = False
@@ -80,7 +80,7 @@ class FibonacciStrategy(MartingaleStrategy):
                 self.http_client, self.user_id, self.user_hash
             )
             log(
-                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}, якорь: {self._anchor_ccy}"
+                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}"
             )
         except Exception as e:  # pragma: no cover - сеть
             log(f"[{self.symbol}] ⚠ Не удалось получить баланс при старте: {e}")
@@ -102,7 +102,7 @@ class FibonacciStrategy(MartingaleStrategy):
                 self._last_signal_ver = st.get("version", 0) or 0
                 if self.log:
                     self.log(
-                        f"[{self.symbol}] Заякорена версия сигнала: v{self._last_signal_ver}"
+                        f"[{self.symbol}] Версия сигнала: v{self._last_signal_ver}"
                     )
             else:
                 self._last_signal_ver = 0

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -150,7 +150,7 @@ class FixedStakeStrategy(StrategyBase):
         try:
             self._anchor_is_demo = await is_demo_account(self.http_client)
             mode_txt = "ДЕМО" if self._anchor_is_demo else "РЕАЛ"
-            log(f"[{self.symbol}] Якорный режим счёта: {mode_txt}")
+            log(f"[{self.symbol}] Режим счёта: {mode_txt}")
         except Exception as e:
             log(f"[{self.symbol}] ⚠ Не удалось определить режим счёта при старте: {e}")
             self._anchor_is_demo = False
@@ -160,7 +160,7 @@ class FixedStakeStrategy(StrategyBase):
                 self.http_client, self.user_id, self.user_hash
             )
             log(
-                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}, якорь: {self._anchor_ccy}"
+                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}"
             )
         except Exception as e:
             log(f"[{self.symbol}] ⚠ Не удалось получить баланс при старте: {e}")
@@ -180,7 +180,7 @@ class FixedStakeStrategy(StrategyBase):
                 self._last_signal_ver = st.get("version", 0) or 0
                 if self.log:
                     self.log(
-                        f"[{self.symbol}] Заякорена версия сигнала: v{self._last_signal_ver}"
+                        f"[{self.symbol}] Версия сигнала: v{self._last_signal_ver}"
                     )
             else:
                 self._last_signal_ver = 0

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -154,7 +154,7 @@ class MartingaleStrategy(StrategyBase):
         try:
             self._anchor_is_demo = await is_demo_account(self.http_client)
             mode_txt = "ДЕМО" if self._anchor_is_demo else "РЕАЛ"
-            log(f"[{self.symbol}] Якорный режим счёта: {mode_txt}")
+            log(f"[{self.symbol}] Режим счёта: {mode_txt}")
         except Exception as e:
             log(f"[{self.symbol}] ⚠ Не удалось определить режим счёта при старте: {e}")
             self._anchor_is_demo = False
@@ -164,7 +164,7 @@ class MartingaleStrategy(StrategyBase):
                 self.http_client, self.user_id, self.user_hash
             )
             log(
-                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}, якорь: {self._anchor_ccy}"
+                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}"
             )
         except Exception as e:
             log(f"[{self.symbol}] ⚠ Не удалось получить баланс при старте: {e}")
@@ -184,7 +184,7 @@ class MartingaleStrategy(StrategyBase):
                 self._last_signal_ver = st.get("version", 0) or 0
                 if self.log:
                     self.log(
-                        f"[{self.symbol}] Заякорена версия сигнала: v{self._last_signal_ver}"
+                        f"[{self.symbol}] Версия сигнала: v{self._last_signal_ver}"
                     )
             else:
                 self._last_signal_ver = 0

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -146,7 +146,7 @@ class OscarGrind2Strategy(StrategyBase):
         try:
             self._anchor_is_demo = await is_demo_account(self.http_client)
             mode_txt = "ДЕМО" if self._anchor_is_demo else "РЕАЛ"
-            log(f"[{self.symbol}] Якорный режим счёта: {mode_txt}")
+            log(f"[{self.symbol}] Режим счёта: {mode_txt}")
         except Exception as e:
             log(f"[{self.symbol}] ⚠ Не удалось определить режим счёта при старте: {e}")
             self._anchor_is_demo = False
@@ -157,7 +157,7 @@ class OscarGrind2Strategy(StrategyBase):
                 self.http_client, self.user_id, self.user_hash
             )
             log(
-                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}, якорь: {self._anchor_ccy}"
+                f"[{self.symbol}] Баланс: {display} ({format_amount(amount)}), текущая валюта: {cur_ccy}"
             )
         except Exception as e:
             log(f"[{self.symbol}] ⚠ Не удалось получить баланс при старте: {e}")
@@ -177,7 +177,7 @@ class OscarGrind2Strategy(StrategyBase):
                 st = peek_signal_state(self.symbol, self.timeframe)
                 self._last_signal_ver = st.get("version", 0) or 0
                 log(
-                    f"[{self.symbol}] Заякорена версия сигнала: v{self._last_signal_ver}"
+                    f"[{self.symbol}] Версия сигнала: v{self._last_signal_ver}"
                 )
             else:
                 self._last_signal_ver = 0


### PR DESCRIPTION
## Summary
- Open strategy control in a standard window instead of a modal dialog and rename delete button to "Удалить бота".
- Clean strategy log messages by removing anchor-related wording and aligning them with AntiMartingale style.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9060372d08322be8a08844dc54a90