### PR TITLE
Update bot settings window logging and behavior

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -239,6 +239,7 @@ class MainWindow(QWidget):
         self.bot_last_tick: dict[Bot, float] = {}
         self.bot_pause_buttons: dict[Bot, QPushButton] = {}
         self.bot_stop_buttons: dict[Bot, QPushButton] = {}
+        self._strategy_windows: dict[Bot, QWidget] = {}
 
         # Тикер для апдейта "Время работы"
         self._bots_timer = QTimer(self)
@@ -481,8 +482,26 @@ class MainWindow(QWidget):
     def open_strategy_control_dialog(self, bot):
         from gui.strategy_control_dialog import StrategyControlDialog
 
+        existing = self._strategy_windows.get(bot)
+        if existing:
+            try:
+                existing.showNormal()
+                existing.raise_()
+                existing.activateWindow()
+                return
+            except RuntimeError:
+                self._strategy_windows.pop(bot, None)
+
         dlg = StrategyControlDialog(self, bot, parent=self)
-        dlg.exec()
+
+        def _cleanup(*_):
+            self._strategy_windows.pop(bot, None)
+
+        dlg.destroyed.connect(_cleanup)
+        self._strategy_windows[bot] = dlg
+        dlg.show()
+        dlg.raise_()
+        dlg.activateWindow()
 
     def stop_bot(self, bot):
         bot.stop()

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -1,6 +1,7 @@
 # gui/strategy_control_dialog.py
+import json
+import math
 from PyQt6.QtWidgets import (
-    QDialog,
     QVBoxLayout,
     QHBoxLayout,
     QLabel,
@@ -22,7 +23,6 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtGui import QColor, QBrush, QTextCursor
 from PyQt6.QtCore import QTimer, Qt
-from core.money import format_amount
 from strategies.martingale import _minutes_from_timeframe
 from core.policy import normalize_sprint
 from core.money import format_money
@@ -36,15 +36,16 @@ from core.templates import (
 )
 
 
-class StrategyControlDialog(QDialog):
+class StrategyControlDialog(QWidget):
     """
     Единое окно: статус + пер-ботовый лог + ВСТРОЕННЫЕ НАСТРОЙКИ + управление
     + СПРАВА таблица сделок этого бота.
     """
 
     def __init__(self, main_window, bot, parent=None):
-        super().__init__(parent)
+        super().__init__(parent, Qt.WindowType.Window)
         self.setWindowTitle("Управление стратегией")
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
         self.main = main_window
         self.bot = bot
 
@@ -520,22 +521,44 @@ class StrategyControlDialog(QDialog):
         if new_params is None:
             return
 
-        self.bot.strategy_kwargs.setdefault("params", {}).update(new_params)
-        if self.bot.strategy and hasattr(self.bot.strategy, "update_params"):
-            self.bot.strategy.update_params(**new_params)
-
         if new_params.get("minutes") and self.minutes is not None:
             self.minutes.setValue(int(new_params["minutes"]))
 
-        formatted = []
-        for k, v in new_params.items():
-            if isinstance(v, float):
-                formatted.append(f"'{k}': {format_amount(v)}")
-            else:
-                formatted.append(f"'{k}': {v}")
-        self._add_log(
-            ts("💾 Настройки применены: {" + ", ".join(formatted) + "}")
+        params_storage = self.bot.strategy_kwargs.setdefault("params", {})
+
+        changed_params = {}
+        for key, value in new_params.items():
+            if not self._values_equal(params_storage.get(key), value):
+                changed_params[key] = value
+
+        if not changed_params:
+            return
+
+        params_storage.update(changed_params)
+
+        if self.bot.strategy and hasattr(self.bot.strategy, "update_params"):
+            self.bot.strategy.update_params(**changed_params)
+
+        snapshot = json.dumps(
+            params_storage,
+            ensure_ascii=False,
+            separators=(", ", ": "),
+            sort_keys=True,
         )
+        self._add_log(ts(f"💾 Настройки применены: {snapshot}"))
+
+    @staticmethod
+    def _values_equal(old, new) -> bool:
+        if isinstance(old, bool) or isinstance(new, bool):
+            return bool(old) == bool(new)
+        try:
+            if isinstance(old, (int, float)) or isinstance(new, (int, float)):
+                return math.isclose(
+                    float(old), float(new), rel_tol=1e-9, abs_tol=1e-9
+                )
+        except (TypeError, ValueError):
+            return False
+        return old == new
 
     def save_template(self):
         new_params = self._collect_params()

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,6 +1,7 @@
 # strategies/base.py
 from __future__ import annotations
 import asyncio
+import json
 from typing import Any, Awaitable, Optional
 
 
@@ -130,13 +131,19 @@ class StrategyBase:
 
     # --- live settings ---
     def update_params(self, **params):
+        if not params:
+            return
+
         self.params.update(params)
         if hasattr(self, "log") and self.log:
             pretty = {
                 k: (round(v, 8) if isinstance(v, float) else v)
                 for k, v in params.items()
             }
-            self.log(f"[{self.symbol}] ⚙ Параметры обновлены: {pretty}")
+            payload = json.dumps(
+                pretty, ensure_ascii=False, separators=(", ", ": "), sort_keys=True
+            )
+            self.log(f"[{self.symbol}] ⚙ Параметры обновлены: {payload}")
 
     def get_param(self, key, default=None):
         return self.params.get(key, default)


### PR DESCRIPTION
## Summary
- convert the strategy control dialog into a standard top-level window that can be reopened and reused
- apply and log bot settings only when values change and emit JSON-formatted messages
- update live strategy parameter logging to output JSON for consistency

## Testing
- python -m compileall gui strategies

------
https://chatgpt.com/codex/tasks/task_e_68da9b7ae33c83229de1e0ebce50604f