### PR TITLE
Improve bot cleanup and template helpers

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from typing import Any, Callable, Optional, Type
 
 
@@ -46,43 +47,28 @@ class Bot:
         try:
             await self._strategy.run()
         except asyncio.CancelledError:
-            try:
-                self._strategy.stop()
-            except Exception:
-                pass
+            self._call_strategy_method("stop")
             raise
         finally:
             # аккуратно закрываем per-bot HttpClient, если он есть
-            try:
-                client = getattr(self._strategy, "http_client", None)
-                if client is not None:
-                    close_coro = getattr(client, "aclose", None) or getattr(
-                        client, "close", None
-                    )
-                    if callable(close_coro):
-                        await close_coro()
-            except Exception:
-                pass
+            await self._close_http_client()
 
             self._started = False
             self.on_finish()
 
     def stop(self) -> None:
         """Остановить стратегию и отменить асинхронную задачу."""
-        if self._strategy:
-            self._strategy.stop()
+        self._call_strategy_method("stop")
         if self._task and not self._task.done():
             self._task.cancel()
 
     def pause(self) -> None:
         """Поставить стратегию на паузу, если она поддерживает паузу."""
-        if self._strategy:
-            self._strategy.pause()
+        self._call_strategy_method("pause")
 
     def resume(self) -> None:
         """Возобновить стратегию после паузы."""
-        if self._strategy:
-            self._strategy.resume()
+        self._call_strategy_method("resume")
 
     def is_running(self) -> bool:
         """Проверить, выполняется ли задача стратегии."""
@@ -96,3 +82,36 @@ class Bot:
     def strategy(self) -> Optional[Any]:
         """Возвращает инстанс стратегии (если запущен)."""
         return self._strategy
+
+    def _call_strategy_method(self, name: str) -> None:
+        """Вызвать метод стратегии, если он существует и вызываем."""
+        if not self._strategy:
+            return
+        method = getattr(self._strategy, name, None)
+        if callable(method):
+            try:
+                method()
+            except Exception:
+                pass
+
+    async def _close_http_client(self) -> None:
+        """Закрыть HttpClient стратегии, если он задан."""
+        if not self._strategy:
+            return
+        client = getattr(self._strategy, "http_client", None)
+        if client is None:
+            return
+
+        close_callable = getattr(client, "aclose", None)
+        if close_callable is None:
+            close_callable = getattr(client, "close", None)
+
+        if not callable(close_callable):
+            return
+
+        try:
+            result = close_callable()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            pass

--- a/core/templates.py
+++ b/core/templates.py
@@ -1,60 +1,60 @@
+"""Persistence helpers for strategy templates."""
+
+from __future__ import annotations
+
 import json
 from pathlib import Path
-from typing import List, Dict
+from typing import Any
+
+Template = dict[str, Any]
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 LAST_USED_FILE = TEMPLATES_DIR / "last_used.json"
 
 
-def load_templates(strategy_key: str) -> List[Dict]:
-    """Load list of templates for a given strategy."""
-    path = TEMPLATES_DIR / f"{strategy_key}.json"
+def _read_json(path: Path) -> Any:
     if not path.exists():
-        return []
+        return None
     try:
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        if isinstance(data, list):
-            return data
-    except Exception:
-        pass
+        with path.open("r", encoding="utf-8") as fp:
+            return json.load(fp)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def load_templates(strategy_key: str) -> list[Template]:
+    """Load list of templates for a given strategy."""
+    data = _read_json(TEMPLATES_DIR / f"{strategy_key}.json")
+    if isinstance(data, list):
+        return [tmpl for tmpl in data if isinstance(tmpl, dict)]
     return []
 
 
-def save_templates(strategy_key: str, templates: List[Dict]) -> None:
+def save_templates(strategy_key: str, templates: list[Template]) -> None:
     """Persist templates for a strategy."""
     path = TEMPLATES_DIR / f"{strategy_key}.json"
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(templates, f, ensure_ascii=False, indent=2)
+    with path.open("w", encoding="utf-8") as fp:
+        json.dump(templates, fp, ensure_ascii=False, indent=2)
 
 
 def load_last_template(strategy_key: str) -> str | None:
     """Return name of last used template for strategy or None."""
-    if not LAST_USED_FILE.exists():
-        return None
-    try:
-        with open(LAST_USED_FILE, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        if isinstance(data, dict):
-            return data.get(strategy_key)
-    except Exception:
-        return None
+    data = _read_json(LAST_USED_FILE)
+    if isinstance(data, dict):
+        value = data.get(strategy_key)
+        return str(value) if isinstance(value, str) else None
     return None
 
 
 def save_last_template(strategy_key: str, name: str) -> None:
     """Persist last used template name for strategy."""
-    data: Dict[str, str] = {}
-    if LAST_USED_FILE.exists():
-        try:
-            with open(LAST_USED_FILE, "r", encoding="utf-8") as f:
-                obj = json.load(f)
-            if isinstance(obj, dict):
-                data = obj
-        except Exception:
-            pass
+    data: dict[str, str] = {}
+    existing = _read_json(LAST_USED_FILE)
+    if isinstance(existing, dict):
+        data.update({k: str(v) for k, v in existing.items() if isinstance(v, str)})
+
     data[strategy_key] = name
     LAST_USED_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(LAST_USED_FILE, "w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
+    with LAST_USED_FILE.open("w", encoding="utf-8") as fp:
+        json.dump(data, fp, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- ensure bots call optional lifecycle hooks defensively and close HTTP clients reliably
- refactor template persistence helpers to centralise JSON handling and ignore invalid records

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68db59604c2083229a15888df27b0d80