### PR TITLE
Rename parallel trade option and enable by default

### DIFF
--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -167,8 +167,8 @@ class StrategyControlDialog(QWidget):
         th.addWidget(self.btn_apply_template)
         box_v.addWidget(template_row)
 
-        self.parallel_trades = QCheckBox("Искать новые сигналы во время ожидания")
-        self.parallel_trades.setChecked(bool(getv("allow_parallel_trades", False)))
+        self.parallel_trades = QCheckBox("Обрабатывать множество сигналов")
+        self.parallel_trades.setChecked(bool(getv("allow_parallel_trades", True)))
 
         if strategy_key in ("oscar_grind_1", "oscar_grind_2"):
             self.minutes = QSpinBox()

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -38,7 +38,7 @@ DEFAULTS = {
     "result_wait_s": 60.0,
     "grace_delay_sec": 30.0,
     "trade_type": "classic",
-    "allow_parallel_trades": False,
+    "allow_parallel_trades": True,
 }
 
 
@@ -122,7 +122,7 @@ class FixedStakeStrategy(StrategyBase):
         self._on_status = self.params.get("on_status")
 
         self._allow_parallel_trades = bool(
-            self.params.get("allow_parallel_trades", False)
+            self.params.get("allow_parallel_trades", True)
         )
         self.params["allow_parallel_trades"] = self._allow_parallel_trades
 


### PR DESCRIPTION
## Summary
- rename the parallel trade checkbox label to "Обрабатывать множество сигналов"
- default the checkbox and strategy parameter to enabled for new bots

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef3e8823248322a8f429f4e1dd01b3