### PR TITLE
Add allow_parallel_trades support across strategies

### DIFF
--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -38,6 +38,7 @@ DEFAULTS = {
     "result_wait_s": 60.0,
     "grace_delay_sec": 30.0,
     "trade_type": "classic",
+    "allow_parallel_trades": True,
 }
 
 
@@ -136,6 +137,11 @@ class AntiMartingaleStrategy(StrategyBase):
         self._last_signal_at_str: Optional[str] = None
         self._next_expire_dt = None
         self._last_signal_monotonic: Optional[float] = None
+
+        self._allow_parallel_trades = bool(
+            self.params.get("allow_parallel_trades", True)
+        )
+        self.params["allow_parallel_trades"] = self._allow_parallel_trades
 
         anchor = str(
             self.params.get("account_currency", DEFAULTS["account_currency"])
@@ -658,6 +664,10 @@ class AntiMartingaleStrategy(StrategyBase):
         if "trade_type" in params:
             self._trade_type = str(params["trade_type"]).lower()
             self.params["trade_type"] = self._trade_type
+
+        if "allow_parallel_trades" in params:
+            self._allow_parallel_trades = bool(params["allow_parallel_trades"])
+            self.params["allow_parallel_trades"] = self._allow_parallel_trades
 
     def _max_signal_age_seconds(self) -> float:
         if self._trade_type == "classic":

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -40,6 +40,7 @@ DEFAULTS = {
     "result_wait_s": 60.0,
     "grace_delay_sec": 30.0,
     "trade_type": "classic",
+    "allow_parallel_trades": True,
 }
 
 
@@ -140,6 +141,11 @@ class MartingaleStrategy(StrategyBase):
         )
         self._next_expire_dt = None
         self._last_signal_monotonic: Optional[float] = None
+
+        self._allow_parallel_trades = bool(
+            self.params.get("allow_parallel_trades", True)
+        )
+        self.params["allow_parallel_trades"] = self._allow_parallel_trades
 
         anchor = str(
             self.params.get("account_currency", DEFAULTS["account_currency"])
@@ -672,6 +678,10 @@ class MartingaleStrategy(StrategyBase):
         if "trade_type" in params:
             self._trade_type = str(params["trade_type"]).lower()
             self.params["trade_type"] = self._trade_type
+
+        if "allow_parallel_trades" in params:
+            self._allow_parallel_trades = bool(params["allow_parallel_trades"])
+            self.params["allow_parallel_trades"] = self._allow_parallel_trades
 
     def _max_signal_age_seconds(self) -> float:
         if self._trade_type == "classic":

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -52,6 +52,7 @@ DEFAULTS = {
     # Поведение серии: повторный вход после поражения
     "double_entry": True,
     "trade_type": "classic",
+    "allow_parallel_trades": True,
 }
 
 
@@ -132,6 +133,11 @@ class OscarGrind2Strategy(StrategyBase):
         self._last_signal_at_str: Optional[str] = None
         self._next_expire_dt = None
         self._last_signal_monotonic: Optional[float] = None
+
+        self._allow_parallel_trades = bool(
+            self.params.get("allow_parallel_trades", True)
+        )
+        self.params["allow_parallel_trades"] = self._allow_parallel_trades
 
         anchor = str(
             self.params.get("account_currency", DEFAULTS["account_currency"])
@@ -745,6 +751,10 @@ class OscarGrind2Strategy(StrategyBase):
         if "trade_type" in params:
             self._trade_type = str(params["trade_type"]).lower()
             self.params["trade_type"] = self._trade_type
+
+        if "allow_parallel_trades" in params:
+            self._allow_parallel_trades = bool(params["allow_parallel_trades"])
+            self.params["allow_parallel_trades"] = self._allow_parallel_trades
 
     def _max_signal_age_seconds(self) -> float:
         if self._trade_type == "classic":

--- a/templates/fibonacci.json
+++ b/templates/fibonacci.json
@@ -1,6 +1,8 @@
 [
   {
     "name": "Шаблон 1",
-    "params": {}
+    "params": {
+      "allow_parallel_trades": true
+    }
   }
 ]

--- a/templates/martingale.json
+++ b/templates/martingale.json
@@ -8,7 +8,8 @@
       "repeat_count": 10,
       "min_balance": 100,
       "coefficient": 2.0,
-      "min_percent": 70
+      "min_percent": 70,
+      "allow_parallel_trades": true
     }
   },
   {
@@ -20,7 +21,8 @@
       "repeat_count": 10,
       "min_balance": 100,
       "coefficient": 2.0,
-      "min_percent": 70
+      "min_percent": 70,
+      "allow_parallel_trades": true
     }
   },
   {
@@ -32,7 +34,8 @@
       "repeat_count": 10,
       "min_balance": 100,
       "coefficient": 2.0,
-      "min_percent": 70
+      "min_percent": 70,
+      "allow_parallel_trades": true
     }
   },
   {
@@ -44,7 +47,8 @@
       "min_balance": 100,
       "coefficient": 2.0,
       "min_percent": 70,
-      "trade_type": "classic"
+      "trade_type": "classic",
+      "allow_parallel_trades": true
     }
   }
 ]

--- a/templates/oscar_grind_2.json
+++ b/templates/oscar_grind_2.json
@@ -8,7 +8,8 @@
       "min_balance": 100,
       "min_percent": 70,
       "double_entry": true,
-      "trade_type": "classic"
+      "trade_type": "classic",
+      "allow_parallel_trades": true
     }
   }
 ]


### PR DESCRIPTION
## Summary
- add the allow_parallel_trades parameter to AntiMartingale, Martingale, and Oscar Grind strategies
- ensure live parameter updates keep the allow_parallel_trades flag in sync
- surface the allow_parallel_trades flag in the Martingale, Fibonacci, and Oscar Grind templates so the toggle is persisted

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef3f9cdc748322b046516237a8650e