### PR TITLE
Add parallel trade toggle to strategy template dialogs

### DIFF
--- a/gui/settings_antimartin.py
+++ b/gui/settings_antimartin.py
@@ -3,6 +3,8 @@ from PyQt6.QtWidgets import (
     QFormLayout,
     QSpinBox,
     QDialogButtonBox,
+    QCheckBox,
+    QLabel,
 )
 from strategies.martingale import _minutes_from_timeframe
 from core.policy import normalize_sprint
@@ -43,6 +45,13 @@ class AntimartinSettingsDialog(QDialog):
         self.min_percent.setRange(0, 100)
         self.min_percent.setValue(self.params.get("min_percent", 70))
 
+        self.parallel_trades = QCheckBox()
+        self.parallel_trades.setChecked(
+            bool(self.params.get("allow_parallel_trades", True))
+        )
+        parallel_label = QLabel("Обрабатывать множество сигналов")
+        parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
+
         form = QFormLayout()
         form.addRow("Базовая ставка", self.base_investment)
         form.addRow("Время экспирации (мин)", self.minutes)
@@ -50,6 +59,7 @@ class AntimartinSettingsDialog(QDialog):
         form.addRow("Повторов серии", self.repeat_count)
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
+        form.addRow(parallel_label, self.parallel_trades)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -74,4 +84,5 @@ class AntimartinSettingsDialog(QDialog):
             "repeat_count": self.repeat_count.value(),
             "min_balance": self.min_balance.value(),
             "min_percent": self.min_percent.value(),
+            "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
         }

--- a/gui/settings_fibonacci.py
+++ b/gui/settings_fibonacci.py
@@ -3,6 +3,8 @@ from PyQt6.QtWidgets import (
     QFormLayout,
     QSpinBox,
     QDialogButtonBox,
+    QCheckBox,
+    QLabel,
 )
 from strategies.martingale import _minutes_from_timeframe
 from core.policy import normalize_sprint
@@ -42,6 +44,13 @@ class FibonacciSettingsDialog(QDialog):
         self.min_percent.setRange(0, 100)
         self.min_percent.setValue(self.params.get("min_percent", 70))
 
+        self.parallel_trades = QCheckBox()
+        self.parallel_trades.setChecked(
+            bool(self.params.get("allow_parallel_trades", True))
+        )
+        parallel_label = QLabel("Обрабатывать множество сигналов")
+        parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
+
         form = QFormLayout()
         form.addRow("Базовая ставка", self.base_investment)
         form.addRow("Время экспирации (мин)", self.minutes)
@@ -49,6 +58,7 @@ class FibonacciSettingsDialog(QDialog):
         form.addRow("Повторов серии", self.repeat_count)
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
+        form.addRow(parallel_label, self.parallel_trades)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -72,4 +82,5 @@ class FibonacciSettingsDialog(QDialog):
             "repeat_count": self.repeat_count.value(),
             "min_balance": self.min_balance.value(),
             "min_percent": self.min_percent.value(),
+            "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
         }

--- a/gui/settings_fixed.py
+++ b/gui/settings_fixed.py
@@ -3,6 +3,8 @@ from PyQt6.QtWidgets import (
     QFormLayout,
     QSpinBox,
     QDialogButtonBox,
+    QCheckBox,
+    QLabel,
 )
 from strategies.martingale import _minutes_from_timeframe
 from core.policy import normalize_sprint
@@ -38,12 +40,20 @@ class FixedSettingsDialog(QDialog):
         self.min_percent.setRange(0, 100)
         self.min_percent.setValue(self.params.get("min_percent", 70))
 
+        self.parallel_trades = QCheckBox()
+        self.parallel_trades.setChecked(
+            bool(self.params.get("allow_parallel_trades", True))
+        )
+        parallel_label = QLabel("Обрабатывать множество сигналов")
+        parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
+
         form = QFormLayout()
         form.addRow("Базовая ставка", self.base_investment)
         form.addRow("Время экспирации (мин)", self.minutes)
         form.addRow("Количество ставок", self.repeat_count)
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
+        form.addRow(parallel_label, self.parallel_trades)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -66,5 +76,6 @@ class FixedSettingsDialog(QDialog):
             "repeat_count": self.repeat_count.value(),
             "min_balance": self.min_balance.value(),
             "min_percent": self.min_percent.value(),
+            "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
         }
 

--- a/gui/settings_martingale.py
+++ b/gui/settings_martingale.py
@@ -4,6 +4,8 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QDoubleSpinBox,
     QDialogButtonBox,
+    QCheckBox,
+    QLabel,
 )
 from strategies.martingale import _minutes_from_timeframe
 from core.policy import normalize_sprint
@@ -51,6 +53,13 @@ class MartingaleSettingsDialog(QDialog):
         self.min_percent.setRange(0, 100)
         self.min_percent.setValue(self.params.get("min_percent", 70))
 
+        self.parallel_trades = QCheckBox()
+        self.parallel_trades.setChecked(
+            bool(self.params.get("allow_parallel_trades", True))
+        )
+        parallel_label = QLabel("Обрабатывать множество сигналов")
+        parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
+
         form = QFormLayout()
         form.addRow("Базовая ставка", self.base_investment)
         form.addRow("Время экспирации (мин)", self.minutes)
@@ -59,6 +68,7 @@ class MartingaleSettingsDialog(QDialog):
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Коэффициент", self.coefficient)
         form.addRow("Мин. процент", self.min_percent)
+        form.addRow(parallel_label, self.parallel_trades)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -85,4 +95,5 @@ class MartingaleSettingsDialog(QDialog):
             "min_balance": self.min_balance.value(),
             "coefficient": self.coefficient.value(),
             "min_percent": self.min_percent.value(),
+            "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
         }

--- a/gui/settings_oscar_grind.py
+++ b/gui/settings_oscar_grind.py
@@ -58,6 +58,13 @@ class OscarGrindSettingsDialog(QDialog):
         double_entry_label = QLabel("Двойной вход на свечу")
         double_entry_label.mousePressEvent = lambda event: self.double_entry.toggle()
 
+        self.parallel_trades = QCheckBox()
+        self.parallel_trades.setChecked(
+            bool(self.params.get("allow_parallel_trades", True))
+        )
+        parallel_label = QLabel("Обрабатывать множество сигналов")
+        parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
+
         form = QFormLayout()
         form.addRow("Базовая ставка (unit)", self.base_investment)
         form.addRow("Время экспирации (мин)", self.minutes)
@@ -66,6 +73,7 @@ class OscarGrindSettingsDialog(QDialog):
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
         form.addRow(double_entry_label, self.double_entry)
+        form.addRow(parallel_label, self.parallel_trades)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -92,4 +100,5 @@ class OscarGrindSettingsDialog(QDialog):
             "min_balance": int(self.min_balance.value()),
             "min_percent": int(self.min_percent.value()),
             "double_entry": bool(self.double_entry.isChecked()),
+            "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
         }


### PR DESCRIPTION
## Summary
- add the "Обрабатывать множество сигналов" checkbox to every strategy settings dialog used in the template manager
- persist the allow_parallel_trades flag when templates are saved

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef44ceebe8832282828e75fbcc40e7