### PR TITLE
Enable parallel trade handling in remaining strategies

### DIFF
--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -131,6 +131,9 @@ class AntiMartingaleStrategy(StrategyBase):
 
         self._status = _status
 
+        self._pending_tasks: set[asyncio.Task] = set()
+        self._pending_for_status: dict[str, tuple[str, str]] = {}
+
         self._running = False
         self._last_signal_ver: Optional[int] = None
         self._last_indicator: str = "-"
@@ -456,33 +459,30 @@ class AntiMartingaleStrategy(StrategyBase):
                     except Exception:
                         pass
 
-                self._status("ожидание результата")
+                self._register_pending_trade(trade_id, self.symbol, self.timeframe)
 
-                profit = await check_trade_result(
-                    self.http_client,
-                    user_id=self.user_id,
-                    user_hash=self.user_hash,
+                wait_ctx = dict(
                     trade_id=trade_id,
-                    wait_time=wait_seconds,
+                    wait_seconds=float(wait_seconds),
+                    placed_at=placed_at_str,
+                    signal_at=self._last_signal_at_str,
+                    symbol=self.symbol,
+                    timeframe=self.timeframe,
+                    direction=status,
+                    stake=float(stake),
+                    percent=int(pct),
+                    account_mode=account_mode,
+                    indicator=self._last_indicator,
                 )
 
-                if callable(self._on_trade_result):
-                    try:
-                        self._on_trade_result(
-                            trade_id=trade_id,
-                            symbol=self.symbol,
-                            timeframe=self.timeframe,
-                            signal_at=self._last_signal_at_str,
-                            placed_at=placed_at_str,
-                            direction=status,
-                            stake=float(stake),
-                            percent=int(pct),
-                            profit=(None if profit is None else float(profit)),
-                            account_mode=account_mode,
-                            indicator=self._last_indicator,
-                        )
-                    except Exception:
-                        pass
+                if self._allow_parallel_trades:
+                    task = asyncio.create_task(
+                        self._wait_for_trade_result(log=log, **wait_ctx)
+                    )
+                    self._launch_trade_result_task(task)
+                    profit = await task
+                else:
+                    profit = await self._wait_for_trade_result(log=log, **wait_ctx)
 
                 if profit is None:
                     log(f"[{self.symbol}] ⚠ Результат неизвестен — считаем как LOSS.")
@@ -522,8 +522,110 @@ class AntiMartingaleStrategy(StrategyBase):
                 series_left -= 1
                 log(f"[{self.symbol}] ▶ Осталось серий: {series_left}")
 
+        if self._pending_tasks:
+            await asyncio.gather(*list(self._pending_tasks), return_exceptions=True)
+            self._pending_tasks.clear()
+
         self._running = False
         (self.log or (lambda s: None))(f"[{self.symbol}] Завершение стратегии.")
+
+    def _update_pending_status(self) -> None:
+        if not self._pending_for_status:
+            self._status("ожидание сигнала")
+            return
+
+        parts = []
+        for symbol, timeframe in self._pending_for_status.values():
+            sym = str(symbol or "-")
+            tf = str(timeframe or "-")
+            parts.append(f"{sym} {tf}")
+
+        if not parts:
+            self._status("ожидание сигнала")
+            return
+
+        shown = parts[:3]
+        extra = len(parts) - len(shown)
+        text = ", ".join(shown)
+        if extra > 0:
+            text += f" +{extra}"
+        self._status(f"ожидание результата: {text}")
+
+    def _register_pending_trade(self, trade_id: str, symbol: str, timeframe: str) -> None:
+        self._pending_for_status[str(trade_id)] = (symbol, timeframe)
+        self._update_pending_status()
+
+    def _unregister_pending_trade(self, trade_id: str) -> None:
+        self._pending_for_status.pop(str(trade_id), None)
+        self._update_pending_status()
+
+    def _launch_trade_result_task(self, task: asyncio.Task) -> None:
+        self._pending_tasks.add(task)
+
+        def _cleanup(_: asyncio.Future) -> None:
+            self._pending_tasks.discard(task)
+
+        task.add_done_callback(_cleanup)
+
+    async def _wait_for_trade_result(
+        self,
+        *,
+        log,
+        trade_id: str,
+        wait_seconds: float,
+        placed_at: str,
+        signal_at: Optional[str],
+        symbol: str,
+        timeframe: str,
+        direction: int,
+        stake: float,
+        percent: int,
+        account_mode: Optional[str],
+        indicator: str,
+    ):
+        try:
+            self._status("ожидание результата")
+            profit = await check_trade_result(
+                self.http_client,
+                user_id=self.user_id,
+                user_hash=self.user_hash,
+                trade_id=trade_id,
+                wait_time=wait_seconds,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            log(
+                f"[{symbol}] ⚠ Ошибка получения результата сделки {trade_id}: {e}"
+            )
+            profit = None
+
+        if callable(self._on_trade_result):
+            try:
+                self._on_trade_result(
+                    trade_id=trade_id,
+                    symbol=symbol,
+                    timeframe=timeframe,
+                    signal_at=signal_at,
+                    placed_at=placed_at,
+                    direction=direction,
+                    stake=float(stake),
+                    percent=int(percent),
+                    profit=(None if profit is None else float(profit)),
+                    account_mode=account_mode,
+                    indicator=indicator,
+                )
+            except Exception:
+                pass
+
+        self._unregister_pending_trade(trade_id)
+        return profit
+
+    def stop(self):
+        for task in list(self._pending_tasks):
+            task.cancel()
+        self._pending_for_status.clear()
+        super().stop()
 
     async def _ensure_anchor_currency(self) -> bool:
         try:

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -355,33 +355,30 @@ class FibonacciStrategy(MartingaleStrategy):
                     except Exception:
                         pass
 
-                self._status("ожидание результата")
+                self._register_pending_trade(trade_id, self.symbol, self.timeframe)
 
-                profit = await check_trade_result(
-                    self.http_client,
-                    user_id=self.user_id,
-                    user_hash=self.user_hash,
+                wait_ctx = dict(
                     trade_id=trade_id,
-                    wait_time=wait_seconds,
+                    wait_seconds=float(wait_seconds),
+                    placed_at=placed_at_str,
+                    signal_at=self._last_signal_at_str,
+                    symbol=self.symbol,
+                    timeframe=self.timeframe,
+                    direction=status,
+                    stake=float(stake),
+                    percent=int(pct),
+                    account_mode=account_mode,
+                    indicator=self._last_indicator,
                 )
 
-                if callable(self._on_trade_result):
-                    try:
-                        self._on_trade_result(
-                            trade_id=trade_id,
-                            symbol=self.symbol,
-                            timeframe=self.timeframe,
-                            signal_at=self._last_signal_at_str,
-                            placed_at=placed_at_str,
-                            direction=status,
-                            stake=float(stake),
-                            percent=int(pct),
-                            profit=(None if profit is None else float(profit)),
-                            account_mode=account_mode,
-                            indicator=self._last_indicator,
-                        )
-                    except Exception:
-                        pass
+                if self._allow_parallel_trades:
+                    task = asyncio.create_task(
+                        self._wait_for_trade_result(log=log, **wait_ctx)
+                    )
+                    self._launch_trade_result_task(task)
+                    profit = await task
+                else:
+                    profit = await self._wait_for_trade_result(log=log, **wait_ctx)
 
                 if profit is None:
                     log(f"[{self.symbol}] ⚠ Результат неизвестен — считаем как LOSS.")
@@ -420,6 +417,10 @@ class FibonacciStrategy(MartingaleStrategy):
                     next_start_step = 1
                 series_left -= 1
                 log(f"[{self.symbol}] ▶ Осталось серий: {series_left}")
+
+        if self._pending_tasks:
+            await asyncio.gather(*list(self._pending_tasks), return_exceptions=True)
+            self._pending_tasks.clear()
 
         self._running = False
         (self.log or (lambda s: None))(f"[{self.symbol}] Завершение стратегии.")

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -133,6 +133,9 @@ class MartingaleStrategy(StrategyBase):
 
         self._status = _status
 
+        self._pending_tasks: set[asyncio.Task] = set()
+        self._pending_for_status: dict[str, tuple[str, str]] = {}
+
         self._running = False
         self._last_signal_ver: Optional[int] = None
         self._last_indicator: str = "-"
@@ -463,33 +466,30 @@ class MartingaleStrategy(StrategyBase):
                     except Exception:
                         pass
 
-                self._status("ожидание результата")
+                self._register_pending_trade(trade_id, self.symbol, self.timeframe)
 
-                profit = await check_trade_result(
-                    self.http_client,
-                    user_id=self.user_id,
-                    user_hash=self.user_hash,
+                wait_ctx = dict(
                     trade_id=trade_id,
-                    wait_time=wait_seconds,
+                    wait_seconds=float(wait_seconds),
+                    placed_at=placed_at_str,
+                    signal_at=self._last_signal_at_str,
+                    symbol=self.symbol,
+                    timeframe=self.timeframe,
+                    direction=status,
+                    stake=float(stake),
+                    percent=int(pct),
+                    account_mode=account_mode,
+                    indicator=self._last_indicator,
                 )
 
-                if callable(self._on_trade_result):
-                    try:
-                        self._on_trade_result(
-                            trade_id=trade_id,
-                            symbol=self.symbol,
-                            timeframe=self.timeframe,
-                            signal_at=self._last_signal_at_str,
-                            placed_at=placed_at_str,
-                            direction=status,
-                            stake=float(stake),
-                            percent=int(pct),
-                            profit=(None if profit is None else float(profit)),
-                            account_mode=account_mode,
-                            indicator=self._last_indicator,
-                        )
-                    except Exception:
-                        pass
+                if self._allow_parallel_trades:
+                    task = asyncio.create_task(
+                        self._wait_for_trade_result(log=log, **wait_ctx)
+                    )
+                    self._launch_trade_result_task(task)
+                    profit = await task
+                else:
+                    profit = await self._wait_for_trade_result(log=log, **wait_ctx)
 
                 if profit is None:
                     log(f"[{self.symbol}] ⚠ Результат неизвестен — считаем как LOSS.")
@@ -535,6 +535,10 @@ class MartingaleStrategy(StrategyBase):
                     )
                 series_left -= 1
                 log(f"[{self.symbol}] ▶ Осталось серий: {series_left}")
+
+        if self._pending_tasks:
+            await asyncio.gather(*list(self._pending_tasks), return_exceptions=True)
+            self._pending_tasks.clear()
 
         self._running = False
         (self.log or (lambda s: None))(f"[{self.symbol}] Завершение стратегии.")
@@ -689,3 +693,102 @@ class MartingaleStrategy(StrategyBase):
         if self._trade_type == "sprint":
             return SPRINT_SIGNAL_MAX_AGE_SEC
         return 0.0
+
+    def _update_pending_status(self) -> None:
+        if not self._pending_for_status:
+            self._status("ожидание сигнала")
+            return
+
+        parts = []
+        for symbol, timeframe in self._pending_for_status.values():
+            sym = str(symbol or "-")
+            tf = str(timeframe or "-")
+            parts.append(f"{sym} {tf}")
+
+        if not parts:
+            self._status("ожидание сигнала")
+            return
+
+        shown = parts[:3]
+        extra = len(parts) - len(shown)
+        text = ", ".join(shown)
+        if extra > 0:
+            text += f" +{extra}"
+        self._status(f"ожидание результата: {text}")
+
+    def _register_pending_trade(self, trade_id: str, symbol: str, timeframe: str) -> None:
+        self._pending_for_status[str(trade_id)] = (symbol, timeframe)
+        self._update_pending_status()
+
+    def _unregister_pending_trade(self, trade_id: str) -> None:
+        self._pending_for_status.pop(str(trade_id), None)
+        self._update_pending_status()
+
+    def _launch_trade_result_task(self, task: asyncio.Task) -> None:
+        self._pending_tasks.add(task)
+
+        def _cleanup(_: asyncio.Future) -> None:
+            self._pending_tasks.discard(task)
+
+        task.add_done_callback(_cleanup)
+
+    async def _wait_for_trade_result(
+        self,
+        *,
+        log,
+        trade_id: str,
+        wait_seconds: float,
+        placed_at: str,
+        signal_at: Optional[str],
+        symbol: str,
+        timeframe: str,
+        direction: int,
+        stake: float,
+        percent: int,
+        account_mode: Optional[str],
+        indicator: str,
+    ):
+        try:
+            self._status("ожидание результата")
+            profit = await check_trade_result(
+                self.http_client,
+                user_id=self.user_id,
+                user_hash=self.user_hash,
+                trade_id=trade_id,
+                wait_time=wait_seconds,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            log(
+                f"[{symbol}] ⚠ Ошибка получения результата сделки {trade_id}: {e}"
+            )
+            profit = None
+
+        if callable(self._on_trade_result):
+            try:
+                self._on_trade_result(
+                    trade_id=trade_id,
+                    symbol=symbol,
+                    timeframe=timeframe,
+                    signal_at=signal_at,
+                    placed_at=placed_at,
+                    direction=direction,
+                    stake=float(stake),
+                    percent=int(percent),
+                    profit=(None if profit is None else float(profit)),
+                    account_mode=account_mode,
+                    indicator=indicator,
+                )
+            except Exception:
+                pass
+
+        self._unregister_pending_trade(trade_id)
+        return profit
+
+    def stop(self):
+        for task in list(self._pending_tasks):
+            task.cancel()
+        self._pending_for_status.clear()
+        super().stop()
+

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -127,6 +127,9 @@ class OscarGrind2Strategy(StrategyBase):
 
         self._status = _status
 
+        self._pending_tasks: set[asyncio.Task] = set()
+        self._pending_for_status: dict[str, tuple[str, str]] = {}
+
         self._running = False
         self._last_signal_ver: Optional[int] = None
         self._last_indicator: str = "-"
@@ -461,34 +464,30 @@ class OscarGrind2Strategy(StrategyBase):
                     except Exception:
                         pass
 
-                self._status("ожидание результата")
+                self._register_pending_trade(trade_id, self.symbol, self.timeframe)
 
-                profit = await check_trade_result(
-                    self.http_client,
-                    user_id=self.user_id,
-                    user_hash=self.user_hash,
+                wait_ctx = dict(
                     trade_id=trade_id,
-                    wait_time=wait_seconds,
+                    wait_seconds=float(wait_seconds),
+                    placed_at=placed_at_str,
+                    signal_at=self._last_signal_at_str,
+                    symbol=self.symbol,
+                    timeframe=self.timeframe,
+                    direction=status,
+                    stake=float(stake),
+                    percent=int(pct),
+                    account_mode=account_mode,
+                    indicator=self._last_indicator,
                 )
 
-                # GUI: результат
-                if callable(self._on_trade_result):
-                    try:
-                        self._on_trade_result(
-                            trade_id=trade_id,
-                            symbol=self.symbol,
-                            timeframe=self.timeframe,
-                            signal_at=self._last_signal_at_str,
-                            placed_at=placed_at_str,
-                            direction=status,
-                            stake=float(stake),
-                            percent=int(pct),
-                            profit=(None if profit is None else float(profit)),
-                            account_mode=account_mode,
-                            indicator=self._last_indicator,
-                        )
-                    except Exception:
-                        pass
+                if self._allow_parallel_trades:
+                    task = asyncio.create_task(
+                        self._wait_for_trade_result(log=log, **wait_ctx)
+                    )
+                    self._launch_trade_result_task(task)
+                    profit = await task
+                else:
+                    profit = await self._wait_for_trade_result(log=log, **wait_ctx)
 
                 # Определим исход сделки
                 if profit is None:
@@ -574,6 +573,10 @@ class OscarGrind2Strategy(StrategyBase):
                 series_left -= 1
                 log(f"[{self.symbol}] ▶ Осталось серий: {series_left}")
 
+        if self._pending_tasks:
+            await asyncio.gather(*list(self._pending_tasks), return_exceptions=True)
+            self._pending_tasks.clear()
+
         self._running = False
         (self.log or (lambda s: None))(f"[{self.symbol}] Завершение стратегии.")
 
@@ -642,6 +645,104 @@ class OscarGrind2Strategy(StrategyBase):
             await self.sleep(1.0)
             return False
         return True
+
+    def _update_pending_status(self) -> None:
+        if not self._pending_for_status:
+            self._status("ожидание сигнала")
+            return
+
+        parts = []
+        for symbol, timeframe in self._pending_for_status.values():
+            sym = str(symbol or "-")
+            tf = str(timeframe or "-")
+            parts.append(f"{sym} {tf}")
+
+        if not parts:
+            self._status("ожидание сигнала")
+            return
+
+        shown = parts[:3]
+        extra = len(parts) - len(shown)
+        text = ", ".join(shown)
+        if extra > 0:
+            text += f" +{extra}"
+        self._status(f"ожидание результата: {text}")
+
+    def _register_pending_trade(self, trade_id: str, symbol: str, timeframe: str) -> None:
+        self._pending_for_status[str(trade_id)] = (symbol, timeframe)
+        self._update_pending_status()
+
+    def _unregister_pending_trade(self, trade_id: str) -> None:
+        self._pending_for_status.pop(str(trade_id), None)
+        self._update_pending_status()
+
+    def _launch_trade_result_task(self, task: asyncio.Task) -> None:
+        self._pending_tasks.add(task)
+
+        def _cleanup(_: asyncio.Future) -> None:
+            self._pending_tasks.discard(task)
+
+        task.add_done_callback(_cleanup)
+
+    async def _wait_for_trade_result(
+        self,
+        *,
+        log,
+        trade_id: str,
+        wait_seconds: float,
+        placed_at: str,
+        signal_at: Optional[str],
+        symbol: str,
+        timeframe: str,
+        direction: int,
+        stake: float,
+        percent: int,
+        account_mode: Optional[str],
+        indicator: str,
+    ):
+        try:
+            self._status("ожидание результата")
+            profit = await check_trade_result(
+                self.http_client,
+                user_id=self.user_id,
+                user_hash=self.user_hash,
+                trade_id=trade_id,
+                wait_time=wait_seconds,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            log(
+                f"[{symbol}] ⚠ Ошибка получения результата сделки {trade_id}: {e}"
+            )
+            profit = None
+
+        if callable(self._on_trade_result):
+            try:
+                self._on_trade_result(
+                    trade_id=trade_id,
+                    symbol=symbol,
+                    timeframe=timeframe,
+                    signal_at=signal_at,
+                    placed_at=placed_at,
+                    direction=direction,
+                    stake=float(stake),
+                    percent=int(percent),
+                    profit=(None if profit is None else float(profit)),
+                    account_mode=account_mode,
+                    indicator=indicator,
+                )
+            except Exception:
+                pass
+
+        self._unregister_pending_trade(trade_id)
+        return profit
+
+    def stop(self):
+        for task in list(self._pending_tasks):
+            task.cancel()
+        self._pending_for_status.clear()
+        super().stop()
 
     async def wait_signal(self, *, timeout: float) -> int:
         grace = float(self.params.get("grace_delay_sec", DEFAULTS["grace_delay_sec"]))


### PR DESCRIPTION
## Summary
- respect the allow_parallel_trades toggle in Martingale-based strategies by tracking pending trades and delegating result waits through reusable helpers
- extend AntiMartingale, Fibonacci, and Oscar Grind strategies to register pending trades, update status texts, and share the same asynchronous result handling flow
- ensure all strategies flush and cancel pending tasks on shutdown to avoid dangling waits when parallel trade handling is enabled

## Testing
- python -m compileall strategies

------
https://chatgpt.com/codex/tasks/task_e_68ef51663fcc83228dbad79d7e49f1a9