### PR TITLE
Add async signal queues for trading strategies

### DIFF
--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -618,6 +618,8 @@ class AntiMartingaleStrategy(StrategyBase):
 
         self._running = False
 
+        await self._cancel_signal_listener()
+
         if self._pending_tasks:
             await asyncio.gather(*list(self._pending_tasks), return_exceptions=True)
             self._pending_tasks.clear()
@@ -655,7 +657,9 @@ class AntiMartingaleStrategy(StrategyBase):
             return False
         return True
 
-    async def wait_signal(self, *, timeout: float) -> int:
+    async def _fetch_signal_payload(
+        self, since_version: Optional[int]
+    ) -> tuple[int, int, dict[str, Optional[str | int | float]]]:
         grace = float(self.params.get("grace_delay_sec", DEFAULTS["grace_delay_sec"]))
 
         def _on_delay(sec: float):
@@ -663,11 +667,15 @@ class AntiMartingaleStrategy(StrategyBase):
                 f"[{self.symbol}] ⏱ Задержка следующего прогноза ~{sec:.1f}s"
             )
 
+        listen_symbol = "*" if self._use_any_symbol else self.symbol
+        listen_timeframe = "*" if self._use_any_timeframe else self.timeframe
+        current_version = since_version
+
         while True:
             coro = wait_for_signal_versioned(
-                self.symbol,
-                self.timeframe,
-                since_version=self._last_signal_ver,
+                listen_symbol,
+                listen_timeframe,
+                since_version=current_version,
                 check_pause=self.is_paused,
                 timeout=None,
                 raise_on_timeout=True,
@@ -677,46 +685,56 @@ class AntiMartingaleStrategy(StrategyBase):
                 max_age_sec=self._max_signal_age_seconds(),
             )
 
-            direction, ver, meta = await self.wait_cancellable(coro, timeout=timeout)
-            sig_symbol = (meta or {}).get("symbol") or self.symbol
-            sig_tf = ((meta or {}).get("timeframe") or self.timeframe).upper()
+            direction, ver, meta = await self.wait_cancellable(coro, timeout=None)
+            current_version = ver
+
+            sig_symbol = (meta or {}).get("symbol") or listen_symbol
+            sig_tf = ((meta or {}).get("timeframe") or listen_timeframe).upper()
 
             if (
                 self._use_any_timeframe
                 and self._trade_type == "classic"
                 and sig_tf not in CLASSIC_ALLOWED_TFS
             ):
-                self._last_signal_ver = ver
                 if self.log:
                     self.log(
                         f"[{sig_symbol}] ⚠ Таймфрейм {sig_tf} недоступен для Classic — пропуск."
                     )
                 continue
 
-            self._last_signal_ver = ver
-            self._last_indicator = (meta or {}).get("indicator") or "-"
+            return int(direction), int(ver), meta
 
-            ts = (meta or {}).get("next_timestamp")
-            self._next_expire_dt = ts.astimezone(MOSCOW_TZ) if ts else None
+    async def wait_signal(self, *, timeout: float) -> int:
+        await self._ensure_signal_listener(self._fetch_signal_payload)
 
-            if self._use_any_symbol:
-                self.symbol = sig_symbol
-            if self._use_any_timeframe:
-                self.timeframe = sig_tf
-                self.params["timeframe"] = self.timeframe
-                raw = _minutes_from_timeframe(self.timeframe)
-                norm = normalize_sprint(self.symbol, raw) or raw
-                self._trade_minutes = int(norm)
-                self.params["minutes"] = self._trade_minutes
+        direction, ver, meta = await self._next_signal_from_queue(timeout=timeout)
+        sig_symbol = (meta or {}).get("symbol") or self.symbol
+        sig_tf = ((meta or {}).get("timeframe") or self.timeframe).upper()
 
-            from datetime import datetime
+        self._last_signal_ver = ver
+        self._last_indicator = (meta or {}).get("indicator") or "-"
 
-            self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
-            try:
-                self._last_signal_monotonic = asyncio.get_running_loop().time()
-            except RuntimeError:
-                self._last_signal_monotonic = None
-            return int(direction)
+        ts = (meta or {}).get("next_timestamp")
+        self._next_expire_dt = ts.astimezone(MOSCOW_TZ) if ts else None
+
+        if self._use_any_symbol:
+            self.symbol = sig_symbol
+        if self._use_any_timeframe:
+            self.timeframe = sig_tf
+            self.params["timeframe"] = self.timeframe
+            raw = _minutes_from_timeframe(self.timeframe)
+            norm = normalize_sprint(self.symbol, raw) or raw
+            self._trade_minutes = int(norm)
+            self.params["minutes"] = self._trade_minutes
+
+        from datetime import datetime
+
+        self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+        try:
+            self._last_signal_monotonic = asyncio.get_running_loop().time()
+        except RuntimeError:
+            self._last_signal_monotonic = None
+        return int(direction)
 
     def update_params(self, **params):
         super().update_params(**params)

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -422,6 +422,8 @@ class FibonacciStrategy(MartingaleStrategy):
 
         self._running = False
 
+        await self._cancel_signal_listener()
+
         if self._pending_tasks:
             await asyncio.gather(*list(self._pending_tasks), return_exceptions=True)
             self._pending_tasks.clear()

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -632,6 +632,8 @@ class MartingaleStrategy(StrategyBase):
 
         self._running = False
 
+        await self._cancel_signal_listener()
+
         if self._pending_tasks:
             await asyncio.gather(*list(self._pending_tasks), return_exceptions=True)
             self._pending_tasks.clear()
@@ -669,7 +671,9 @@ class MartingaleStrategy(StrategyBase):
             return False
         return True
 
-    async def wait_signal(self, *, timeout: float) -> int:
+    async def _fetch_signal_payload(
+        self, since_version: Optional[int]
+    ) -> tuple[int, int, dict[str, Optional[str | int | float]]]:
         grace = float(self.params.get("grace_delay_sec", DEFAULTS["grace_delay_sec"]))
 
         def _on_delay(sec: float):
@@ -677,11 +681,15 @@ class MartingaleStrategy(StrategyBase):
                 f"[{self.symbol}] ⏱ Задержка следующего прогноза ~{sec:.1f}s"
             )
 
+        listen_symbol = "*" if self._use_any_symbol else self.symbol
+        listen_timeframe = "*" if self._use_any_timeframe else self.timeframe
+        current_version = since_version
+
         while True:
             coro = wait_for_signal_versioned(
-                self.symbol,
-                self.timeframe,
-                since_version=self._last_signal_ver,
+                listen_symbol,
+                listen_timeframe,
+                since_version=current_version,
                 check_pause=self.is_paused,
                 timeout=None,
                 raise_on_timeout=True,
@@ -691,46 +699,56 @@ class MartingaleStrategy(StrategyBase):
                 max_age_sec=self._max_signal_age_seconds(),
             )
 
-            direction, ver, meta = await self.wait_cancellable(coro, timeout=timeout)
-            sig_symbol = (meta or {}).get("symbol") or self.symbol
-            sig_tf = ((meta or {}).get("timeframe") or self.timeframe).upper()
+            direction, ver, meta = await self.wait_cancellable(coro, timeout=None)
+            current_version = ver
+
+            sig_symbol = (meta or {}).get("symbol") or listen_symbol
+            sig_tf = ((meta or {}).get("timeframe") or listen_timeframe).upper()
 
             if (
                 self._use_any_timeframe
                 and self._trade_type == "classic"
                 and sig_tf not in CLASSIC_ALLOWED_TFS
             ):
-                self._last_signal_ver = ver
                 if self.log:
                     self.log(
                         f"[{sig_symbol}] ⚠ Таймфрейм {sig_tf} недоступен для Classic — пропуск."
                     )
                 continue
 
-            self._last_signal_ver = ver
-            self._last_indicator = (meta or {}).get("indicator") or "-"
+            return int(direction), int(ver), meta
 
-            ts = (meta or {}).get("next_timestamp")
-            self._next_expire_dt = ts.astimezone(MOSCOW_TZ) if ts else None
+    async def wait_signal(self, *, timeout: float) -> int:
+        await self._ensure_signal_listener(self._fetch_signal_payload)
 
-            if self._use_any_symbol:
-                self.symbol = sig_symbol
-            if self._use_any_timeframe:
-                self.timeframe = sig_tf
-                self.params["timeframe"] = self.timeframe
-                raw = _minutes_from_timeframe(self.timeframe)
-                norm = normalize_sprint(self.symbol, raw) or raw
-                self._trade_minutes = int(norm)
-                self.params["minutes"] = self._trade_minutes
+        direction, ver, meta = await self._next_signal_from_queue(timeout=timeout)
+        sig_symbol = (meta or {}).get("symbol") or self.symbol
+        sig_tf = ((meta or {}).get("timeframe") or self.timeframe).upper()
 
-            from datetime import datetime
+        self._last_signal_ver = ver
+        self._last_indicator = (meta or {}).get("indicator") or "-"
 
-            self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
-            try:
-                self._last_signal_monotonic = asyncio.get_running_loop().time()
-            except RuntimeError:
-                self._last_signal_monotonic = None
-            return int(direction)
+        ts = (meta or {}).get("next_timestamp")
+        self._next_expire_dt = ts.astimezone(MOSCOW_TZ) if ts else None
+
+        if self._use_any_symbol:
+            self.symbol = sig_symbol
+        if self._use_any_timeframe:
+            self.timeframe = sig_tf
+            self.params["timeframe"] = self.timeframe
+            raw = _minutes_from_timeframe(self.timeframe)
+            norm = normalize_sprint(self.symbol, raw) or raw
+            self._trade_minutes = int(norm)
+            self.params["minutes"] = self._trade_minutes
+
+        from datetime import datetime
+
+        self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+        try:
+            self._last_signal_monotonic = asyncio.get_running_loop().time()
+        except RuntimeError:
+            self._last_signal_monotonic = None
+        return int(direction)
 
     def update_params(self, **params):
         super().update_params(**params)

--- a/strategies/oscar_grind_2.py
+++ b/strategies/oscar_grind_2.py
@@ -669,6 +669,8 @@ class OscarGrind2Strategy(StrategyBase):
 
         self._running = False
 
+        await self._cancel_signal_listener()
+
         if self._pending_tasks:
             await asyncio.gather(*list(self._pending_tasks), return_exceptions=True)
             self._pending_tasks.clear()
@@ -741,7 +743,9 @@ class OscarGrind2Strategy(StrategyBase):
             return False
         return True
 
-    async def wait_signal(self, *, timeout: float) -> int:
+    async def _fetch_signal_payload(
+        self, since_version: Optional[int]
+    ) -> tuple[int, int, dict[str, Optional[str | int | float]]]:
         grace = float(self.params.get("grace_delay_sec", DEFAULTS["grace_delay_sec"]))
 
         def _on_delay(sec: float):
@@ -749,11 +753,15 @@ class OscarGrind2Strategy(StrategyBase):
                 f"[{self.symbol}] ⏱ Задержка следующего прогноза ~{sec:.1f}s"
             )
 
+        listen_symbol = "*" if self._use_any_symbol else self.symbol
+        listen_timeframe = "*" if self._use_any_timeframe else self.timeframe
+        current_version = since_version
+
         while True:
             coro = wait_for_signal_versioned(
-                self.symbol,
-                self.timeframe,
-                since_version=self._last_signal_ver,
+                listen_symbol,
+                listen_timeframe,
+                since_version=current_version,
                 check_pause=self.is_paused,
                 timeout=None,
                 raise_on_timeout=True,
@@ -763,46 +771,56 @@ class OscarGrind2Strategy(StrategyBase):
                 max_age_sec=self._max_signal_age_seconds(),
             )
 
-            direction, ver, meta = await self.wait_cancellable(coro, timeout=timeout)
-            sig_symbol = (meta or {}).get("symbol") or self.symbol
-            sig_tf = ((meta or {}).get("timeframe") or self.timeframe).upper()
+            direction, ver, meta = await self.wait_cancellable(coro, timeout=None)
+            current_version = ver
+
+            sig_symbol = (meta or {}).get("symbol") or listen_symbol
+            sig_tf = ((meta or {}).get("timeframe") or listen_timeframe).upper()
 
             if (
                 self._use_any_timeframe
                 and self._trade_type == "classic"
                 and sig_tf not in CLASSIC_ALLOWED_TFS
             ):
-                self._last_signal_ver = ver
                 if self.log:
                     self.log(
                         f"[{sig_symbol}] ⚠ Таймфрейм {sig_tf} недоступен для Classic — пропуск."
                     )
                 continue
 
-            self._last_signal_ver = ver
-            self._last_indicator = (meta or {}).get("indicator") or "-"
+            return int(direction), int(ver), meta
 
-            ts = (meta or {}).get("next_timestamp")
-            self._next_expire_dt = ts.astimezone(MOSCOW_TZ) if ts else None
+    async def wait_signal(self, *, timeout: float) -> int:
+        await self._ensure_signal_listener(self._fetch_signal_payload)
 
-            if self._use_any_symbol:
-                self.symbol = sig_symbol
-            if self._use_any_timeframe:
-                self.timeframe = sig_tf
-                self.params["timeframe"] = self.timeframe
-                raw = _minutes_from_timeframe(self.timeframe)
-                norm = normalize_sprint(self.symbol, raw) or raw
-                self._trade_minutes = int(norm)
-                self.params["minutes"] = self._trade_minutes
+        direction, ver, meta = await self._next_signal_from_queue(timeout=timeout)
+        sig_symbol = (meta or {}).get("symbol") or self.symbol
+        sig_tf = ((meta or {}).get("timeframe") or self.timeframe).upper()
 
-            from datetime import datetime
+        self._last_signal_ver = ver
+        self._last_indicator = (meta or {}).get("indicator") or "-"
 
-            self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
-            try:
-                self._last_signal_monotonic = asyncio.get_running_loop().time()
-            except RuntimeError:
-                self._last_signal_monotonic = None
-            return int(direction)
+        ts = (meta or {}).get("next_timestamp")
+        self._next_expire_dt = ts.astimezone(MOSCOW_TZ) if ts else None
+
+        if self._use_any_symbol:
+            self.symbol = sig_symbol
+        if self._use_any_timeframe:
+            self.timeframe = sig_tf
+            self.params["timeframe"] = self.timeframe
+            raw = _minutes_from_timeframe(self.timeframe)
+            norm = normalize_sprint(self.symbol, raw) or raw
+            self._trade_minutes = int(norm)
+            self.params["minutes"] = self._trade_minutes
+
+        from datetime import datetime
+
+        self._last_signal_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
+        try:
+            self._last_signal_monotonic = asyncio.get_running_loop().time()
+        except RuntimeError:
+            self._last_signal_monotonic = None
+        return int(direction)
 
     def update_params(self, **params):
         super().update_params(**params)


### PR DESCRIPTION
## Summary
- add a cancellable signal queue helper to `StrategyBase` so strategies can buffer concurrent signals
- update AntiMartingale, Martingale, Fixed Stake, Oscar Grind, and Fibonacci strategies to use the shared queue while awaiting trade results
- ensure strategies stop the listener cleanly and keep wildcard symbol/timeframe handling intact

## Testing
- python -m compileall strategies

------
https://chatgpt.com/codex/tasks/task_e_68fcad36d8f48322ac5a56ee67f94f99