### PR TITLE
Adjust martingale series counters and queue display

### DIFF
--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -35,6 +35,7 @@ from core.templates import (
     load_last_template,
     save_last_template,
 )
+from core.time_utils import format_local_time
 
 
 class StrategyControlDialog(QWidget):
@@ -930,7 +931,7 @@ class StrategyControlDialog(QWidget):
 
         def _fmt_dt(value) -> str:
             if isinstance(value, datetime):
-                return value.strftime("%H:%M:%S")
+                return format_local_time(value, "%H:%M:%S")
             if hasattr(value, "strftime"):
                 try:
                     return value.strftime("%H:%M:%S")


### PR DESCRIPTION
## Summary
- format signal queue timestamps using the detected local timezone in the strategy dialog
- track remaining martingale series per trade key and reset counters when repeat_count changes
- clear queued signals after martingale losses through a shared StrategyCommon helper

## Testing
- python -m compileall strategies/martingale.py strategies/strategy_common.py gui/strategy_control_dialog.py

------
https://chatgpt.com/codex/tasks/task_e_6909b334e570832eb3b4d23694ad2e57