### PR TITLE
Handle Martingale refund signal cleanup

### DIFF
--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -254,6 +254,10 @@ class MartingaleStrategy(BaseTradingStrategy):
                 break
             elif abs(profit) < 1e-9:
                 log(f"[{symbol}] 🤝 PUSH: возврат ставки. Повтор шага без увеличения.")
+                if hasattr(self, "_common") and self._common is not None:
+                    removed = self._common.discard_signals_for(trade_key)
+                    if removed:
+                        log(f"[{symbol}] 🗑 Удалено сигналов из очередей после PUSH: {removed}")
             else:
                 log(f"[{symbol}] ❌ LOSS: profit={format_amount(profit)}. Увеличиваем ставку.")
                 step += 1  # Продолжаем с тем же направлением и исходным сигналом


### PR DESCRIPTION
## Summary
- clear queued signals after a refunded Martingale trade so the strategy does not reuse stale entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6909b6633dec832ebf15e978140106d7