### PR TITLE
Stop fixed stake strategy when reaching trade limit

### DIFF
--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -121,7 +121,13 @@ class FixedStakeStrategy(BaseTradingStrategy):
         # Проверяем лимит сделок
         max_trades = int(self.params.get("repeat_count", 10))
         if self._trades_counter >= max_trades:
-            log(f"[{symbol}] 🛑 Достигнут лимит сделок ({self._trades_counter}/{max_trades}). Пропускаем сигнал.")
+            if not self.is_stopped():
+                log(
+                    f"[{symbol}] 🛑 Достигнут лимит сделок ({self._trades_counter}/{max_trades}). "
+                    "Останавливаем стратегию."
+                )
+                self._status("достигнут лимит сделок")
+                self.stop()
             return
 
         # Запускаем обработку сделки с фиксированной ставкой
@@ -264,6 +270,8 @@ class FixedStakeStrategy(BaseTradingStrategy):
             self._status(f"сделок осталось: {remaining}")
         else:
             self._status("достигнут лимит сделок")
+            if not self.is_stopped():
+                self.stop()
 
     def _calculate_trade_duration(self, symbol: str) -> tuple[float, float]:
         """Рассчитывает длительность сделки"""


### PR DESCRIPTION
## Summary
- stop the fixed stake strategy once the configured trade limit is reached
- update status messaging so the limit notice is emitted before stopping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6909fc50f4d4832e80e7915e97b23095