### PR TITLE
Defer strategy stop until pending trades finish

### DIFF
--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -121,13 +121,13 @@ class FixedStakeStrategy(BaseTradingStrategy):
         # Проверяем лимит сделок
         max_trades = int(self.params.get("repeat_count", 10))
         if self._trades_counter >= max_trades:
-            if not self.is_stopped():
+            if not self._stop_when_idle_requested:
                 log(
                     f"[{symbol}] 🛑 Достигнут лимит сделок ({self._trades_counter}/{max_trades}). "
-                    "Останавливаем стратегию."
+                    "Ожидание завершения открытых сделок."
                 )
                 self._status("достигнут лимит сделок")
-                self.stop()
+            self._request_stop_when_idle("достигнут лимит сделок")
             return
 
         # Запускаем обработку сделки с фиксированной ставкой
@@ -270,8 +270,7 @@ class FixedStakeStrategy(BaseTradingStrategy):
             self._status(f"сделок осталось: {remaining}")
         else:
             self._status("достигнут лимит сделок")
-            if not self.is_stopped():
-                self.stop()
+            self._request_stop_when_idle("достигнут лимит сделок")
 
     def _calculate_trade_duration(self, symbol: str) -> tuple[float, float]:
         """Рассчитывает длительность сделки"""
@@ -331,3 +330,4 @@ class FixedStakeStrategy(BaseTradingStrategy):
                 self._status(f"сделок осталось: {remaining}")
             else:
                 self._status("достигнут лимит сделок")
+                self._request_stop_when_idle("достигнут лимит сделок")


### PR DESCRIPTION
## Summary
- add infrastructure in BaseTradingStrategy to defer stopping until no pending trades remain
- update FixedStake strategy to request a deferred stop when the repeat limit is reached instead of cancelling immediately

## Testing
- python -m compileall strategies

------
https://chatgpt.com/codex/tasks/task_e_6909fee911b8832e987e5f96686ec01d