### PR TITLE
Normalize signal direction labels

### DIFF
--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -940,11 +940,31 @@ class StrategyControlDialog(QWidget):
             return str(value) if value is not None else "—"
 
         def _fmt_dir(value) -> str:
-            if value == 1:
+            if value is None:
+                return "—"
+
+            normalized = value
+            if isinstance(value, str):
+                normalized = value.strip()
+                if not normalized:
+                    return "—"
+                upper = normalized.upper()
+                if upper in {"UP", "CALL"}:
+                    return "ВВЕРХ"
+                if upper in {"DOWN", "PUT"}:
+                    return "ВНИЗ"
+
+            try:
+                int_dir = int(normalized)
+            except (TypeError, ValueError):
+                int_dir = None
+
+            if int_dir == 1:
                 return "ВВЕРХ"
-            if value == -1:
+            if int_dir == -1:
                 return "ВНИЗ"
-            return str(value) if value is not None else "—"
+
+            return str(normalized)
 
         def _extract(items: dict, status: str) -> None:
             if not isinstance(items, dict):

--- a/strategies/strategy_common.py
+++ b/strategies/strategy_common.py
@@ -82,8 +82,14 @@ class StrategyCommon:
                         log(f"[{symbol}] ⏰ Сигнал неактуален для sprint: {reason} -> пропуск")
                         continue
 
+                direction_value: Optional[int]
+                try:
+                    direction_value = int(direction) if direction is not None else None
+                except (TypeError, ValueError):
+                    direction_value = None
+
                 signal_data = {
-                    'direction': direction,
+                    'direction': direction_value,
                     'version': ver,
                     'meta': meta,
                     'symbol': meta.get('symbol') if meta else self.strategy.symbol,


### PR DESCRIPTION
## Summary
- ensure incoming signal directions are normalized to integers before strategies enqueue them
- improve the signal queue formatter so numeric and textual directions are rendered as "ВВЕРХ"/"ВНИЗ"

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a105d59bc832ea17e254eb95935ee