### PR TITLE
Fix DOWN direction display in signal queue

### DIFF
--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -961,7 +961,7 @@ class StrategyControlDialog(QWidget):
 
             if int_dir == 1:
                 return "ВВЕРХ"
-            if int_dir == -1:
+            if int_dir in (-1, 2):
                 return "ВНИЗ"
 
             return str(normalized)


### PR DESCRIPTION
## Summary
- treat numeric direction value 2 as "ВНИЗ" when formatting the signal queue table

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690a120a69c8832ea9772a379bb4c94b