### PR TITLE
Ensure trade placement validates signal freshness

### DIFF
--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -200,6 +200,27 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
             log(f"[{symbol}] step={step} stake={format_amount(current_stake)} min={self._trade_minutes} "
                 f"side={'UP' if series_direction == 1 else 'DOWN'} payout={pct}%")
 
+            # Финальная проверка актуальности перед размещением сделки
+            current_time = datetime.now(ZoneInfo(MOSCOW_TZ))
+            if self._trade_type == "classic":
+                is_valid, reason = self._is_signal_valid_for_classic(
+                    signal_data,
+                    current_time,
+                    for_placement=True,
+                )
+            else:
+                sprint_payload = signal_data
+                if not sprint_payload.get('timestamp'):
+                    sprint_payload = {'timestamp': signal_received_time}
+                is_valid, reason = self._is_signal_valid_for_sprint(
+                    sprint_payload,
+                    current_time,
+                )
+
+            if not is_valid:
+                log(signal_not_actual_for_placement(symbol, reason))
+                return
+
             try:
                 demo_now = await is_demo_account(self.http_client)
             except Exception:

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -286,7 +286,28 @@ class FibonacciStrategy(BaseTradingStrategy):
                     continue
                     
                 log(trade_summary(symbol, format_amount(stake), self._trade_minutes, series_direction, pct) + f" (Fib#{step})")
-                    
+
+                # Финальная проверка актуальности перед размещением сделки
+                current_time = datetime.now(ZoneInfo(MOSCOW_TZ))
+                if self._trade_type == "classic":
+                    is_valid, reason = self._is_signal_valid_for_classic(
+                        signal_data,
+                        current_time,
+                        for_placement=True,
+                    )
+                else:
+                    sprint_payload = signal_data
+                    if not sprint_payload.get('timestamp'):
+                        sprint_payload = {'timestamp': signal_received_time}
+                    is_valid, reason = self._is_signal_valid_for_sprint(
+                        sprint_payload,
+                        current_time,
+                    )
+
+                if not is_valid:
+                    log(signal_not_actual_for_placement(symbol, reason))
+                    return series_left
+
                 # Определяем режим аккаунта
                 try:
                     demo_now = await is_demo_account(self.http_client)

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -200,7 +200,28 @@ class MartingaleStrategy(BaseTradingStrategy):
                 
             log(f"[{symbol}] step={step} stake={format_amount(stake)} min={self._trade_minutes} "
                 f"side={'UP' if series_direction == 1 else 'DOWN'} payout={pct}%")
-                
+
+            # Финальная проверка актуальности перед размещением сделки
+            current_time = datetime.now(ZoneInfo(MOSCOW_TZ))
+            if self._trade_type == "classic":
+                is_valid, reason = self._is_signal_valid_for_classic(
+                    signal_data,
+                    current_time,
+                    for_placement=True,
+                )
+            else:
+                sprint_payload = signal_data
+                if not sprint_payload.get('timestamp'):
+                    sprint_payload = {'timestamp': signal_received_time}
+                is_valid, reason = self._is_signal_valid_for_sprint(
+                    sprint_payload,
+                    current_time,
+                )
+
+            if not is_valid:
+                log(signal_not_actual_for_placement(symbol, reason))
+                return
+
             # Определяем режим аккаунта
             try:
                 demo_now = await is_demo_account(self.http_client)

--- a/strategies/oscar_grind_base.py
+++ b/strategies/oscar_grind_base.py
@@ -165,7 +165,28 @@ class OscarGrindBaseStrategy(BaseTradingStrategy):
                 continue
                 
             log(trade_summary(symbol, format_amount(stake), self._trade_minutes, series_direction, pct) + f" (step {step_idx + 1})")
-            
+
+            # Финальная проверка актуальности перед размещением сделки
+            current_time = datetime.now(ZoneInfo(MOSCOW_TZ))
+            if self._trade_type == "classic":
+                is_valid, reason = self._is_signal_valid_for_classic(
+                    signal_data,
+                    current_time,
+                    for_placement=True,
+                )
+            else:
+                sprint_payload = signal_data
+                if not sprint_payload.get('timestamp'):
+                    sprint_payload = {'timestamp': signal_received_time}
+                is_valid, reason = self._is_signal_valid_for_sprint(
+                    sprint_payload,
+                    current_time,
+                )
+
+            if not is_valid:
+                log(signal_not_actual_for_placement(symbol, reason))
+                return series_left
+
             try:
                 demo_now = await is_demo_account(self.http_client)
             except Exception:


### PR DESCRIPTION
## Summary
- add final freshness checks in every trade loop before calling `place_trade_with_retry`
- skip stale signals after payout waits to avoid executing outdated entries

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690a54936ec0832ea6a7a93555b9b54a