### PR TITLE
Keep series alive when signals expire

### DIFF
--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -183,12 +183,14 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
                     is_valid, reason = self._is_signal_valid_for_classic(signal_data, current_time, for_placement=True)
                     if not is_valid:
                         log(signal_not_actual_for_placement(symbol, reason))
-                        return
+                        await self.sleep(0.5)
+                        continue
                 else:
                     is_valid, reason = self._is_signal_valid_for_sprint({'timestamp': signal_received_time}, current_time)
                     if not is_valid:
                         log(signal_not_actual_for_placement(symbol, reason))
-                        return
+                        await self.sleep(0.5)
+                        continue
 
             min_pct = int(self.params.get("min_percent", 70))
             wait_low = float(self.params.get("wait_on_low_percent", 1))
@@ -219,7 +221,8 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
 
             if not is_valid:
                 log(signal_not_actual_for_placement(symbol, reason))
-                return
+                await self.sleep(0.5)
+                continue
 
             try:
                 demo_now = await is_demo_account(self.http_client)

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -270,8 +270,8 @@ class FibonacciStrategy(BaseTradingStrategy):
                         is_valid, reason = self._is_signal_valid_for_classic(signal_data, current_time, for_placement=True)
                         if not is_valid:
                             log(signal_not_actual_for_placement(symbol, reason))
-                            # Завершить текущую серию (без списания series_left) и ждать условий:
-                            return series_left
+                            await self.sleep(0.5)
+                            continue
                     else:
                         is_valid, reason = self._is_signal_valid_for_sprint(
                             {'timestamp': signal_received_time},
@@ -279,7 +279,8 @@ class FibonacciStrategy(BaseTradingStrategy):
                         )
                         if not is_valid:
                             log(signal_not_actual_for_placement(symbol, reason))
-                            return series_left
+                            await self.sleep(0.5)
+                            continue
 
                 force_validate_signal = False
 
@@ -313,7 +314,8 @@ class FibonacciStrategy(BaseTradingStrategy):
 
                     if not is_valid:
                         log(signal_not_actual_for_placement(symbol, reason))
-                        return series_left
+                        await self.sleep(0.5)
+                        continue
 
                 # Определяем режим аккаунта
                 try:

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -175,7 +175,8 @@ class MartingaleStrategy(BaseTradingStrategy):
                     is_valid, reason = self._is_signal_valid_for_classic(signal_data, current_time, for_placement=True)
                     if not is_valid:
                         log(signal_not_actual_for_placement(symbol, reason))
-                        return
+                        await self.sleep(0.5)
+                        continue
                 else:
                     is_valid, reason = self._is_signal_valid_for_sprint(
                         {'timestamp': signal_received_time},
@@ -183,7 +184,8 @@ class MartingaleStrategy(BaseTradingStrategy):
                     )
                     if not is_valid:
                         log(signal_not_actual_for_placement(symbol, reason))
-                        return
+                        await self.sleep(0.5)
+                        continue
                         
             # Рассчитываем ставку
             base_stake = float(self.params.get("base_investment", 100))
@@ -220,7 +222,8 @@ class MartingaleStrategy(BaseTradingStrategy):
 
             if not is_valid:
                 log(signal_not_actual_for_placement(symbol, reason))
-                return
+                await self.sleep(0.5)
+                continue
 
             # Определяем режим аккаунта
             try:

--- a/strategies/oscar_grind_base.py
+++ b/strategies/oscar_grind_base.py
@@ -150,15 +150,17 @@ class OscarGrindBaseStrategy(BaseTradingStrategy):
                     is_valid, reason = self._is_signal_valid_for_classic(signal_data, current_time, for_placement=True)
                     if not is_valid:
                         log(signal_not_actual_for_placement(symbol, reason))
-                        return series_left
+                        await self.sleep(0.5)
+                        continue
                 else:
                     is_valid, reason = self._is_signal_valid_for_sprint(
-                        {'timestamp': signal_received_time}, 
+                        {'timestamp': signal_received_time},
                         current_time
                     )
                     if not is_valid:
                         log(signal_not_actual_for_placement(symbol, reason))
-                        return series_left
+                        await self.sleep(0.5)
+                        continue
                     
             pct, balance = await self.check_payout_and_balance(symbol, stake, min_pct, wait_low)
             if pct is None:
@@ -185,7 +187,8 @@ class OscarGrindBaseStrategy(BaseTradingStrategy):
 
             if not is_valid:
                 log(signal_not_actual_for_placement(symbol, reason))
-                return series_left
+                await self.sleep(0.5)
+                continue
 
             try:
                 demo_now = await is_demo_account(self.http_client)


### PR DESCRIPTION
## Summary
- update martingale, antimartingale, Fibonacci, and Oscar Grind strategies to pause when a signal becomes stale instead of terminating the current series
- add short waits before re-checking so the strategies idle until a fresh signal arrives

## Testing
- python -m compileall strategies

------
https://chatgpt.com/codex/tasks/task_e_690a6385abe4832e9de51131145b34ac