### PR TITLE
Add simulated trading test mode

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,5 +5,6 @@
     "ws_url": "ws://192.168.56.101:8080",
     "font_family": null,
     "font_size": null,
-    "theme": "system"
+    "theme": "system",
+    "mode": "normal"
 }

--- a/core/config.py
+++ b/core/config.py
@@ -11,6 +11,13 @@ _CONFIG_FILE = "config.json"
 APP_NAME: str = os.getenv("APP_NAME", "Intradevor")
 APP_VERSION: str = os.getenv("APP_VERSION", "1.1.0")
 
+# Режим работы приложения: normal / test
+MODE: str = (
+    os.getenv("APP_MODE")
+    or os.getenv("MODE")
+    or "normal"
+)
+
 domain: str = os.getenv("DOMAIN", "intrade27.bar")
 base_url: str = f"https://{domain}"
 
@@ -57,7 +64,7 @@ def load_config() -> None:
       3) Значения по умолчанию
     Если файла нет — он будет создан с текущими значениями (дефолты/окружение).
     """
-    global APP_NAME, APP_VERSION, domain, base_url, ws_url, FONT_FAMILY, FONT_SIZE, THEME
+    global APP_NAME, APP_VERSION, domain, base_url, ws_url, FONT_FAMILY, FONT_SIZE, THEME, MODE
 
     if not os.path.exists(_CONFIG_FILE):
         # создаём файл с текущими (дефолт/окружение) значениями
@@ -90,6 +97,10 @@ def load_config() -> None:
     if "THEME" not in os.environ:
         THEME = data.get("theme", THEME)
 
+    if "APP_MODE" not in os.environ and "MODE" not in os.environ:
+        value = str(data.get("mode", MODE) or MODE).lower()
+        MODE = value if value in {"normal", "test"} else MODE
+
     base_url = f"https://{domain}"
 
 
@@ -108,6 +119,7 @@ def save_config() -> None:
             "font_family": FONT_FAMILY,
             "font_size": FONT_SIZE,
             "theme": THEME,
+            "mode": MODE,
         }
     )
     _write_json(_CONFIG_FILE, data)
@@ -153,6 +165,14 @@ def get_theme() -> str:
     return THEME
 
 
+def get_mode() -> str:
+    return MODE
+
+
+def is_test_mode() -> bool:
+    return get_mode().lower() == "test"
+
+
 # ===== Опционально: апдейтеры из кода =====
 def set_app_name(name: str) -> None:
     global APP_NAME
@@ -177,3 +197,10 @@ def set_font_size(size: int | None) -> None:
 def set_theme(theme: str) -> None:
     global THEME
     THEME = theme
+
+
+def set_mode(mode: str) -> None:
+    global MODE
+    mode_normalized = (mode or "").strip().lower()
+    if mode_normalized in {"normal", "test"}:
+        MODE = mode_normalized

--- a/core/intrade_api_async.py
+++ b/core/intrade_api_async.py
@@ -6,6 +6,8 @@ from typing import Optional, Tuple
 
 from bs4 import BeautifulSoup
 
+from core import config
+from core import test_backend
 from core.http_async import HttpClient
 from core.policy import DEFAULT_ACCOUNT_CCY, clamp_stake, normalize_sprint
 from core.money import format_amount
@@ -33,6 +35,11 @@ async def get_balance_info(
     """
     Возвращает (amount, currency, display) как sync-версия.
     """
+    if config.is_test_mode():
+        return await test_backend.get_balance_info(
+            client, user_id=user_id, user_hash=user_hash
+        )
+
     payload = {"user_id": user_id, "user_hash": user_hash}
     text = await client.post(PATH_BALANCE, data=payload, expect_json=False)
     amount, currency, display = _parse_balance_text(text)
@@ -75,6 +82,16 @@ async def get_current_percent(
     """
     Совместимая версия: отправляет form-data как sync, возвращает int|None.
     """
+    if config.is_test_mode():
+        return await test_backend.get_current_percent(
+            client,
+            investment=investment,
+            option=option,
+            minutes=minutes,
+            account_ccy=account_ccy,
+            trade_type=trade_type,
+        )
+
     t = "Classic" if str(trade_type).lower() == "classic" else "Sprint"
     payload = {
         "type": t,
@@ -120,6 +137,22 @@ async def place_trade(
       - POST и парсинг HTML ответа для data-id
     Возвращает trade_id или None.
     """
+    if config.is_test_mode():
+        return await test_backend.place_trade(
+            client,
+            user_id=user_id,
+            user_hash=user_hash,
+            investment=investment,
+            option=option,
+            status=status,
+            minutes=minutes,
+            account_ccy=account_ccy,
+            strict=strict,
+            on_log=on_log,
+            trade_type=trade_type,
+            date=date,
+        )
+
     if str(trade_type).lower() == "classic":
         time_value = str(minutes)
     else:
@@ -204,6 +237,14 @@ async def check_trade_result(
 
     Возвращает прибыль (``result - investment``) как ``float``.
     """
+    if config.is_test_mode():
+        return await test_backend.check_trade_result(
+            client,
+            user_id=user_id,
+            user_hash=user_hash,
+            trade_id=trade_id,
+            wait_time=wait_time,
+        )
 
     await asyncio.sleep(wait_time)
     payload = {"user_id": user_id, "user_hash": user_hash, "trade_id": trade_id}
@@ -232,6 +273,11 @@ async def check_trade_result(
 
 
 async def change_currency(client: HttpClient, user_id: str, user_hash: str) -> bool:
+    if config.is_test_mode():
+        return await test_backend.change_currency(
+            client, user_id=user_id, user_hash=user_hash
+        )
+
     payload = {"user_id": user_id, "user_hash": user_hash}
     try:
         await client.post(PATH_CCY, data=payload, expect_json=False)
@@ -247,6 +293,15 @@ async def set_risk(
     risk_min: int | float,
     risk_max: int | float,
 ) -> bool:
+    if config.is_test_mode():
+        return await test_backend.set_risk(
+            client,
+            user_id=user_id,
+            user_hash=user_hash,
+            risk_manage_min=risk_min,
+            risk_manage_max=risk_max,
+        )
+
     payload = {
         "user_id": user_id,
         "user_hash": user_hash,
@@ -266,6 +321,11 @@ async def toggle_real_demo(client: HttpClient, user_id: str, user_hash: str) -> 
     API: POST user_real_trade.php с user_id и user_hash.
     Возвращает True при отсутствии сетевых ошибок (сервер сам переключит режим).
     """
+    if config.is_test_mode():
+        return await test_backend.toggle_real_demo(
+            client, user_id=user_id, user_hash=user_hash
+        )
+
     payload = {"user_id": user_id, "user_hash": user_hash}
     try:
         # Ответ не важен, достаточно, что запрос успешно прошёл
@@ -280,6 +340,9 @@ async def is_demo_account(client: HttpClient) -> bool:
     Проверить, активен ли демо-счёт.
     Признак: в /profile есть <input type="hidden" name="demo_update" value="1">.
     """
+    if config.is_test_mode():
+        return await test_backend.is_demo_account(client)
+
     try:
         html = await client.get(PATH_PROFILE, expect_json=False)
         soup = BeautifulSoup(html, "html.parser")

--- a/core/test_backend.py
+++ b/core/test_backend.py
@@ -1,0 +1,149 @@
+"""Test-mode backend that simulates intradebar HTTP API responses."""
+from __future__ import annotations
+
+import asyncio
+import random
+import uuid
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+__all__ = [
+    "TEST_USER_ID",
+    "TEST_USER_HASH",
+    "initial_cookies",
+    "get_balance_info",
+    "get_current_percent",
+    "place_trade",
+    "check_trade_result",
+    "change_currency",
+    "set_risk",
+    "toggle_real_demo",
+    "is_demo_account",
+]
+
+TEST_USER_ID = "test_user"
+TEST_USER_HASH = "test_hash"
+
+_SYMBOLS = {
+    "RUB": "₽",
+    "USD": "$",
+}
+
+@dataclass
+class _Trade:
+    investment: float
+    win: bool
+    payout: float
+
+
+_FAKE_BALANCE: float = 10_000.0
+_FAKE_CCY: str = "USD"
+_IS_DEMO: bool = True
+_RISK: Tuple[float, float] = (0.0, 0.0)
+_TRADES: Dict[str, _Trade] = {}
+_LOCK = asyncio.Lock()
+
+
+def initial_cookies() -> Dict[str, str]:
+    """Return a minimal cookie set recognised by the app."""
+    return {"user_id": TEST_USER_ID, "user_hash": TEST_USER_HASH}
+
+
+def _format_display(amount: float, currency: str) -> str:
+    display = f"{amount:,.2f}".replace(",", " ")
+    symbol = _SYMBOLS.get(currency.upper(), currency.upper())
+    return f"{display} {symbol}".strip()
+
+
+async def get_balance_info(*_: object, **__: object) -> Tuple[float, str, str]:
+    """Return the simulated balance, currency and display string."""
+    async with _LOCK:
+        return _FAKE_BALANCE, _FAKE_CCY, _format_display(_FAKE_BALANCE, _FAKE_CCY)
+
+
+async def get_current_percent(*_: object, **__: object) -> Optional[int]:
+    """Return a random payout percent between 60 and 95."""
+    return random.randint(60, 95)
+
+
+async def place_trade(
+    *_: object,
+    investment: float | int | str,
+    option: str,
+    status: int,
+    minutes: float | int | str,
+    on_log=None,
+    **__: object,
+) -> Optional[str]:
+    """Register a simulated trade and return its ID."""
+    try:
+        investment_value = float(investment)
+    except (TypeError, ValueError):
+        if on_log:
+            on_log(f"[{option}] ❌ Некорректная сумма ставки: {investment}")
+        return None
+
+    trade_id = str(uuid.uuid4())
+    win = random.random() < 0.5
+    payout = random.uniform(0.65, 0.9)
+
+    async with _LOCK:
+        _TRADES[trade_id] = _Trade(investment=investment_value, win=win, payout=payout)
+
+    if on_log:
+        on_log(
+            f"[{option}] 🧪 Тестовая сделка создана (статус={status}, время={minutes}). "
+            f"ID: {trade_id}"
+        )
+
+    return trade_id
+
+
+async def check_trade_result(
+    *_: object,
+    trade_id: str,
+    wait_time: float = 60.0,
+    **__: object,
+) -> Optional[float]:
+    """Return the simulated profit/loss for the given trade."""
+    await asyncio.sleep(wait_time)
+
+    async with _LOCK:
+        trade = _TRADES.pop(trade_id, None)
+        global _FAKE_BALANCE
+        if trade is None:
+            return None
+
+        profit = trade.investment * trade.payout if trade.win else -trade.investment
+        _FAKE_BALANCE = max(0.0, _FAKE_BALANCE + profit)
+        return profit
+
+
+async def change_currency(*_: object, **__: object) -> bool:
+    """Toggle the simulated account currency between RUB and USD."""
+    async with _LOCK:
+        global _FAKE_CCY
+        _FAKE_CCY = "RUB" if _FAKE_CCY == "USD" else "USD"
+    return True
+
+
+async def set_risk(*_: object, risk_manage_min: float, risk_manage_max: float, **__: object) -> bool:
+    """Store risk settings for completeness."""
+    async with _LOCK:
+        global _RISK
+        _RISK = (float(risk_manage_min), float(risk_manage_max))
+    return True
+
+
+async def toggle_real_demo(*_: object, **__: object) -> bool:
+    """Invert demo/real flag."""
+    async with _LOCK:
+        global _IS_DEMO
+        _IS_DEMO = not _IS_DEMO
+    return True
+
+
+async def is_demo_account(*_: object, **__: object) -> bool:
+    """Return whether the simulated account is in demo mode."""
+    async with _LOCK:
+        return _IS_DEMO


### PR DESCRIPTION
## Summary
- add a configuration mode flag to toggle normal and test behaviour
- provide a test backend that simulates Intradebar API responses with random trade outcomes
- update async API and session helpers to route requests through the simulator when test mode is enabled

## Testing
- python -m compileall core gui strategies main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ece9cefdc832eac6dcf4fb93d8694)