### PR TITLE
Fix signal timestamp propagation for bot trade tables

### DIFF
--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -160,6 +160,7 @@ class MartingaleStrategy(BaseTradingStrategy):
         step = 0
         did_place_any_trade = False
         series_direction = initial_direction
+        signal_at_str = signal_data.get('signal_time_str') or format_local_time(signal_received_time)
         max_steps = int(self.params.get("max_steps", 5))
         
         while self._running and step < max_steps:
@@ -251,8 +252,16 @@ class MartingaleStrategy(BaseTradingStrategy):
                 
             # Уведомляем о pending сделке
             self._notify_pending_trade(
-                trade_id, symbol, timeframe, series_direction, stake, pct,
-                trade_seconds, account_mode, expected_end_ts
+                trade_id,
+                symbol,
+                timeframe,
+                series_direction,
+                stake,
+                pct,
+                trade_seconds,
+                account_mode,
+                expected_end_ts,
+                signal_at=signal_at_str,
             )
             self._register_pending_trade(trade_id, symbol, timeframe)
             
@@ -261,7 +270,7 @@ class MartingaleStrategy(BaseTradingStrategy):
                 trade_id=trade_id,
                 wait_seconds=float(wait_seconds),
                 placed_at=datetime.now().strftime("%d.%m.%Y %H:%M:%S"),
-                signal_at=self._last_signal_at_str,
+                signal_at=signal_at_str,
                 symbol=symbol,
                 timeframe=timeframe,
                 direction=series_direction,
@@ -326,9 +335,18 @@ class MartingaleStrategy(BaseTradingStrategy):
         return trade_seconds, expected_end_ts
 
     def _notify_pending_trade(
-        self, trade_id: str, symbol: str, timeframe: str, direction: int,
-        stake: float, percent: int, trade_seconds: float,
-        account_mode: str, expected_end_ts: float
+        self,
+        trade_id: str,
+        symbol: str,
+        timeframe: str,
+        direction: int,
+        stake: float,
+        percent: int,
+        trade_seconds: float,
+        account_mode: str,
+        expected_end_ts: float,
+        *,
+        signal_at: Optional[str] = None,
     ):
         """Уведомляет о pending сделке"""
         placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
@@ -338,7 +356,7 @@ class MartingaleStrategy(BaseTradingStrategy):
                     trade_id=trade_id,
                     symbol=symbol,
                     timeframe=timeframe,
-                    signal_at=self._last_signal_at_str,
+                    signal_at=signal_at or self._last_signal_at_str,
                     placed_at=placed_at_str,
                     direction=direction,
                     stake=float(stake),

--- a/strategies/strategy_common.py
+++ b/strategies/strategy_common.py
@@ -95,16 +95,17 @@ class StrategyCommon:
                     'symbol': meta.get('symbol') if meta else self.strategy.symbol,
                     'timeframe': meta.get('timeframe') if meta else self.strategy.timeframe,
                     'timestamp': signal_timestamp,
+                    'signal_time_str': format_local_time(signal_timestamp),
                     'indicator': meta.get('indicator') if meta else '-',
                     'next_expire': next_expire,
                 }
-                
+
                 symbol = signal_data['symbol']
                 timeframe = signal_data['timeframe']
                 trade_key = f"{symbol}_{timeframe}"
-                
+
                 self.strategy._last_signal_ver = ver
-                self.strategy._last_signal_at_str = format_local_time(signal_timestamp)
+                self.strategy._last_signal_at_str = signal_data['signal_time_str']
                 
                 # Создаём очередь если её нет
                 if trade_key not in self._signal_queues:


### PR DESCRIPTION
## Summary
- preserve the formatted signal timestamp with each queued signal
- pass the recorded signal time through pending/result notifications across strategies so tables keep the original value
- ensure concurrent signals no longer overwrite the time shown in bot trade tables

## Testing
- python -m compileall strategies

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690edb5e1bb0832ebe9b73478ceeb822)