### PR TITLE
Wait for new Fibonacci signal after losses

### DIFF
--- a/strategies/base_trading_strategy.py
+++ b/strategies/base_trading_strategy.py
@@ -165,6 +165,10 @@ class BaseTradingStrategy(StrategyBase):
         self._trade_type = str(self.params.get("trade_type", "sprint")).lower()
         self.params["trade_type"] = self._trade_type
 
+    def should_request_fresh_signal_after_loss(self) -> bool:
+        """Возвращает True, если стратегии нужен новый сигнал после убыточной сделки."""
+        return False
+
     # === SIGNAL VALIDATION METHODS ===
     def _is_signal_valid_for_classic(self, signal_data: dict, current_time: datetime, for_placement: bool = True) -> tuple[bool, str]:
         """


### PR DESCRIPTION
## Summary
- make the Fibonacci strategy request a fresh signal after loss results
- stop the series when no new signal arrives within the configured timeout

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f3aeb1e00832e8061b4efbb03ffbb)