### PR TITLE
Stop bot after finishing all series

### DIFF
--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -337,6 +337,7 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
             series_left = max(0, series_left - 1)
             self._series_remaining[trade_key] = series_left
             log(series_remaining(symbol, series_left))
+            self._check_all_series_completed(self._series_remaining)
 
     def _calculate_trade_duration(self, symbol: str) -> tuple[float, float]:
         if self._trade_type == "classic" and self._next_expire_dt is not None:

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -516,6 +516,7 @@ class MartingaleStrategy(BaseTradingStrategy):
             series_left = max(0, series_left - 1)
             self._series_remaining[trade_key] = series_left
             log(series_remaining(symbol, series_left))
+            self._check_all_series_completed(self._series_remaining)
 
     # =====================================================================
     # СЛУЖЕБНЫЕ


### PR DESCRIPTION
## Summary
- add a helper to detect when all symbols and timeframes have exhausted their series
- trigger graceful shutdown after the last series completes across antimartingale and martingale strategies
- hook the common series counters into the global completion check

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938d592a194832eaa35fc1275e20cae)