### PR TITLE
Add common series checkbox to strategy settings dialogs

### DIFF
--- a/gui/settings_antimartin.py
+++ b/gui/settings_antimartin.py
@@ -52,6 +52,15 @@ class AntimartinSettingsDialog(QDialog):
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
 
+        self.common_series = QCheckBox()
+        self.common_series.setChecked(
+            bool(self.params.get("use_common_series", False))
+        )
+        common_series_label = QLabel("Общая серия для всех сигналов")
+        common_series_label.mousePressEvent = (
+            lambda event: self.common_series.toggle()
+        )
+
         form = QFormLayout()
         form.addRow("Базовая ставка", self.base_investment)
         form.addRow("Время экспирации (мин)", self.minutes)
@@ -60,6 +69,7 @@ class AntimartinSettingsDialog(QDialog):
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
         form.addRow(parallel_label, self.parallel_trades)
+        form.addRow(common_series_label, self.common_series)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -85,4 +95,5 @@ class AntimartinSettingsDialog(QDialog):
             "min_balance": self.min_balance.value(),
             "min_percent": self.min_percent.value(),
             "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
+            "use_common_series": bool(self.common_series.isChecked()),
         }

--- a/gui/settings_fibonacci.py
+++ b/gui/settings_fibonacci.py
@@ -51,6 +51,15 @@ class FibonacciSettingsDialog(QDialog):
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
 
+        self.common_series = QCheckBox()
+        self.common_series.setChecked(
+            bool(self.params.get("use_common_series", False))
+        )
+        common_series_label = QLabel("Общая серия для всех сигналов")
+        common_series_label.mousePressEvent = (
+            lambda event: self.common_series.toggle()
+        )
+
         form = QFormLayout()
         form.addRow("Базовая ставка", self.base_investment)
         form.addRow("Время экспирации (мин)", self.minutes)
@@ -59,6 +68,7 @@ class FibonacciSettingsDialog(QDialog):
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
         form.addRow(parallel_label, self.parallel_trades)
+        form.addRow(common_series_label, self.common_series)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -83,4 +93,5 @@ class FibonacciSettingsDialog(QDialog):
             "min_balance": self.min_balance.value(),
             "min_percent": self.min_percent.value(),
             "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
+            "use_common_series": bool(self.common_series.isChecked()),
         }

--- a/gui/settings_fixed.py
+++ b/gui/settings_fixed.py
@@ -47,6 +47,15 @@ class FixedSettingsDialog(QDialog):
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
 
+        self.common_series = QCheckBox()
+        self.common_series.setChecked(
+            bool(self.params.get("use_common_series", False))
+        )
+        common_series_label = QLabel("Общая серия для всех сигналов")
+        common_series_label.mousePressEvent = (
+            lambda event: self.common_series.toggle()
+        )
+
         form = QFormLayout()
         form.addRow("Базовая ставка", self.base_investment)
         form.addRow("Время экспирации (мин)", self.minutes)
@@ -54,6 +63,7 @@ class FixedSettingsDialog(QDialog):
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
         form.addRow(parallel_label, self.parallel_trades)
+        form.addRow(common_series_label, self.common_series)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -77,5 +87,6 @@ class FixedSettingsDialog(QDialog):
             "min_balance": self.min_balance.value(),
             "min_percent": self.min_percent.value(),
             "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
+            "use_common_series": bool(self.common_series.isChecked()),
         }
 

--- a/gui/settings_martingale.py
+++ b/gui/settings_martingale.py
@@ -60,6 +60,15 @@ class MartingaleSettingsDialog(QDialog):
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
 
+        self.common_series = QCheckBox()
+        self.common_series.setChecked(
+            bool(self.params.get("use_common_series", False))
+        )
+        common_series_label = QLabel("Общая серия для всех сигналов")
+        common_series_label.mousePressEvent = (
+            lambda event: self.common_series.toggle()
+        )
+
         form = QFormLayout()
         form.addRow("Базовая ставка", self.base_investment)
         form.addRow("Время экспирации (мин)", self.minutes)
@@ -69,6 +78,7 @@ class MartingaleSettingsDialog(QDialog):
         form.addRow("Коэффициент", self.coefficient)
         form.addRow("Мин. процент", self.min_percent)
         form.addRow(parallel_label, self.parallel_trades)
+        form.addRow(common_series_label, self.common_series)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -96,4 +106,5 @@ class MartingaleSettingsDialog(QDialog):
             "coefficient": self.coefficient.value(),
             "min_percent": self.min_percent.value(),
             "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
+            "use_common_series": bool(self.common_series.isChecked()),
         }

--- a/gui/settings_oscar_grind.py
+++ b/gui/settings_oscar_grind.py
@@ -65,6 +65,15 @@ class OscarGrindSettingsDialog(QDialog):
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
 
+        self.common_series = QCheckBox()
+        self.common_series.setChecked(
+            bool(self.params.get("use_common_series", False))
+        )
+        common_series_label = QLabel("Общая серия для всех сигналов")
+        common_series_label.mousePressEvent = (
+            lambda event: self.common_series.toggle()
+        )
+
         form = QFormLayout()
         form.addRow("Базовая ставка (unit)", self.base_investment)
         form.addRow("Время экспирации (мин)", self.minutes)
@@ -74,6 +83,7 @@ class OscarGrindSettingsDialog(QDialog):
         form.addRow("Мин. процент", self.min_percent)
         form.addRow(double_entry_label, self.double_entry)
         form.addRow(parallel_label, self.parallel_trades)
+        form.addRow(common_series_label, self.common_series)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -101,4 +111,5 @@ class OscarGrindSettingsDialog(QDialog):
             "min_percent": int(self.min_percent.value()),
             "double_entry": bool(self.double_entry.isChecked()),
             "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
+            "use_common_series": bool(self.common_series.isChecked()),
         }

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -92,7 +92,7 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
 
         log = self.log or (lambda s: None)
 
-        trade_key = f"{symbol}_{timeframe}"
+        trade_key = self.build_trade_key(symbol, timeframe)
         if trade_key in self._active_series and self._active_series[trade_key]:
             log(series_already_active(symbol, timeframe))
             if hasattr(self, '_common'):
@@ -365,7 +365,7 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
         series_label: Optional[str] = None,
     ):
         placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
-        trade_key = f"{symbol}_{timeframe}"
+        trade_key = self.build_trade_key(symbol, timeframe)
         if series_label is None:
             series_label = self.format_series_label(trade_key)
         self._set_planned_stake(trade_key, stake)

--- a/strategies/base_trading_strategy.py
+++ b/strategies/base_trading_strategy.py
@@ -142,6 +142,17 @@ class BaseTradingStrategy(StrategyBase):
         self._planned_stakes: dict[str, float] = {}
 
     # === UI HELPERS ===
+    def build_trade_key(self, symbol: str, timeframe: str) -> str:
+        """Формирует ключ серии/сделок с учётом настройки общей серии."""
+
+        base_symbol = (symbol or "*").strip()
+        base_timeframe = (timeframe or "*").strip()
+
+        if self.params.get("use_common_series"):
+            return f"common_{self.strategy_name}"
+
+        return f"{base_symbol}_{base_timeframe}"
+
     def format_series_label(
         self, trade_key: str, *, series_left: int | None = None
     ) -> str | None:
@@ -427,7 +438,7 @@ class BaseTradingStrategy(StrategyBase):
             except Exception:
                 pass
 
-        trade_key = f"{symbol}_{timeframe}"
+        trade_key = self.build_trade_key(symbol, timeframe)
         # После завершения сделки планируемая ставка может измениться
         self._planned_stakes.pop(trade_key, None)
 
@@ -699,6 +710,9 @@ class BaseTradingStrategy(StrategyBase):
         if "allow_parallel_trades" in params:
             self._allow_parallel_trades = bool(params["allow_parallel_trades"])
             self.params["allow_parallel_trades"] = self._allow_parallel_trades
+
+        if "use_common_series" in params:
+            self.params["use_common_series"] = bool(params["use_common_series"])
 
         if "repeat_count" in params:
             try:

--- a/strategies/constants.py
+++ b/strategies/constants.py
@@ -23,4 +23,5 @@ DEFAULTS = {
     "classic_signal_max_age_sec": 170.0,
     "classic_trade_buffer_sec": 10.0,
     "classic_min_time_before_next_sec": 180.0,
+    "use_common_series": False,
 }

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -99,7 +99,7 @@ class FibonacciStrategy(BaseTradingStrategy):
         symbol = signal_data['symbol']
         timeframe = signal_data['timeframe']
         direction = signal_data['direction']
-        trade_key = f"{symbol}_{timeframe}"
+        trade_key = self.build_trade_key(symbol, timeframe)
 
         log = self.log or (lambda s: None)
 
@@ -464,7 +464,7 @@ class FibonacciStrategy(BaseTradingStrategy):
     ):
         """Уведомляет о pending сделке"""
         placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
-        trade_key = f"{symbol}_{timeframe}"
+        trade_key = self.build_trade_key(symbol, timeframe)
         if series_label is None:
             series_label = self.format_series_label(trade_key)
         self._set_planned_stake(trade_key, stake)

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -137,7 +137,7 @@ class FixedStakeStrategy(BaseTradingStrategy):
     async def _process_fixed_trade(self, symbol: str, timeframe: str, direction: int, log, signal_received_time: datetime, signal_data: dict):
         """Обрабатывает одну сделку с фиксированной ставкой"""
         signal_at_str = signal_data.get('signal_time_str') or format_local_time(signal_received_time)
-        trade_key = f"{symbol}_{timeframe}"
+        trade_key = self.build_trade_key(symbol, timeframe)
         # Проверяем баланс
         try:
             bal, _, _ = await get_balance_info(
@@ -342,7 +342,7 @@ class FixedStakeStrategy(BaseTradingStrategy):
     ):
         """Уведомляет о pending сделке"""
         placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
-        trade_key = f"{symbol}_{timeframe}"
+        trade_key = self.build_trade_key(symbol, timeframe)
         if series_label is None:
             series_label = self.format_series_label(trade_key)
         self._set_planned_stake(trade_key, stake)

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -173,7 +173,7 @@ class MartingaleStrategy(BaseTradingStrategy):
 
         log = self.log or (lambda s: None)
 
-        trade_key = f"{symbol}_{timeframe}"
+        trade_key = self.build_trade_key(symbol, timeframe)
 
         # 1) Если уже есть активная серия по этому ключу — как раньше:
         #    просто отдаём сигнал в общую очередь StrategyCommon
@@ -552,7 +552,7 @@ class MartingaleStrategy(BaseTradingStrategy):
     ):
         """Уведомляет о pending сделке"""
         placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
-        trade_key = f"{symbol}_{timeframe}"
+        trade_key = self.build_trade_key(symbol, timeframe)
         if series_label is None:
             series_label = self.format_series_label(trade_key)
         self._set_planned_stake(trade_key, stake)

--- a/strategies/oscar_grind_base.py
+++ b/strategies/oscar_grind_base.py
@@ -76,7 +76,7 @@ class OscarGrindBaseStrategy(BaseTradingStrategy):
         symbol = signal_data['symbol']
         timeframe = signal_data['timeframe']
         direction = signal_data['direction']
-        trade_key = f"{symbol}_{timeframe}"
+        trade_key = self.build_trade_key(symbol, timeframe)
 
         log = self.log or (lambda s: None)
         if self._active_series.get(trade_key):
@@ -426,7 +426,7 @@ class OscarGrindBaseStrategy(BaseTradingStrategy):
     ):
         """Уведомляет о pending сделке"""
         placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
-        trade_key = f"{symbol}_{timeframe}"
+        trade_key = self.build_trade_key(symbol, timeframe)
         if series_label is None:
             series_label = self.format_series_label(trade_key)
         self._set_planned_stake(trade_key, stake)

--- a/strategies/strategy_common.py
+++ b/strategies/strategy_common.py
@@ -125,7 +125,7 @@ class StrategyCommon:
 
                 symbol = signal_data['symbol']
                 timeframe = signal_data['timeframe']
-                trade_key = f"{symbol}_{timeframe}"
+                trade_key = self.strategy.build_trade_key(symbol, timeframe)
 
                 self.strategy._last_signal_ver = ver
                 self.strategy._last_signal_at_str = signal_data['signal_time_str']


### PR DESCRIPTION
## Summary
- add the "Общая серия для всех сигналов" checkbox to every strategy settings dialog and pass its value in parameters
- introduce a shared build_trade_key helper and new parameter to allow strategies to use a common series across signals
- update strategy defaults and parameter updates to include the new common-series option

## Testing
- python -m compileall strategies gui

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938e567431c832e91c19a66b041cddf)