### PR TITLE
Add sprint auto duration mode

### DIFF
--- a/gui/settings_antimartin.py
+++ b/gui/settings_antimartin.py
@@ -4,7 +4,9 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QDialogButtonBox,
     QCheckBox,
+    QHBoxLayout,
     QLabel,
+    QWidget,
 )
 from strategies.martingale import _minutes_from_timeframe
 from core.policy import normalize_sprint
@@ -24,6 +26,12 @@ class AntimartinSettingsDialog(QDialog):
         self.minutes = QSpinBox()
         self.minutes.setRange(5 if symbol == "BTCUSDT" else 1, 500)
         self.minutes.setValue(default_minutes)
+
+        self.auto_minutes = QCheckBox("Авто")
+        self.auto_minutes.setChecked(bool(self.params.get("auto_minutes", False)))
+        self.auto_minutes.toggled.connect(
+            lambda checked: self.minutes.setEnabled(not checked)
+        )
 
         self.base_investment = QSpinBox()
         self.base_investment.setRange(1, 50000)
@@ -61,9 +69,17 @@ class AntimartinSettingsDialog(QDialog):
             lambda event: self.common_series.toggle()
         )
 
+        minutes_row = QWidget()
+        minutes_layout = QHBoxLayout(minutes_row)
+        minutes_layout.setContentsMargins(0, 0, 0, 0)
+        minutes_layout.setSpacing(6)
+        minutes_layout.addWidget(self.minutes)
+        minutes_layout.addWidget(self.auto_minutes)
+        minutes_layout.addStretch(1)
+
         form = QFormLayout()
         form.addRow("Базовая ставка", self.base_investment)
-        form.addRow("Время экспирации (мин)", self.minutes)
+        form.addRow("Время экспирации (мин)", minutes_row)
         form.addRow("Макс. шагов", self.max_steps)
         form.addRow("Повторов серии", self.repeat_count)
         form.addRow("Мин. баланс", self.min_balance)
@@ -82,13 +98,15 @@ class AntimartinSettingsDialog(QDialog):
 
     def get_params(self) -> dict:
         symbol = str(self.params.get("symbol", ""))
-        m = int(self.minutes.value())
-        norm = normalize_sprint(symbol, m)
+        auto_minutes = bool(self.auto_minutes.isChecked())
+        raw_minutes = _minutes_from_timeframe(tf) if auto_minutes else int(self.minutes.value())
+        norm = normalize_sprint(symbol, raw_minutes)
         if norm is None:
-            norm = 5 if symbol == "BTCUSDT" else (1 if m < 3 else max(3, min(500, m)))
+            norm = 5 if symbol == "BTCUSDT" else (1 if raw_minutes < 3 else max(3, min(500, raw_minutes)))
 
         return {
             "minutes": int(norm),
+            "auto_minutes": auto_minutes,
             "base_investment": self.base_investment.value(),
             "max_steps": self.max_steps.value(),
             "repeat_count": self.repeat_count.value(),

--- a/gui/settings_fibonacci.py
+++ b/gui/settings_fibonacci.py
@@ -4,7 +4,9 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QDialogButtonBox,
     QCheckBox,
+    QHBoxLayout,
     QLabel,
+    QWidget,
 )
 from strategies.martingale import _minutes_from_timeframe
 from core.policy import normalize_sprint
@@ -23,6 +25,12 @@ class FibonacciSettingsDialog(QDialog):
         self.minutes = QSpinBox()
         self.minutes.setRange(5 if symbol == "BTCUSDT" else 1, 500)
         self.minutes.setValue(default_minutes)
+
+        self.auto_minutes = QCheckBox("Авто")
+        self.auto_minutes.setChecked(bool(self.params.get("auto_minutes", False)))
+        self.auto_minutes.toggled.connect(
+            lambda checked: self.minutes.setEnabled(not checked)
+        )
 
         self.base_investment = QSpinBox()
         self.base_investment.setRange(1, 50000)
@@ -60,9 +68,17 @@ class FibonacciSettingsDialog(QDialog):
             lambda event: self.common_series.toggle()
         )
 
+        minutes_row = QWidget()
+        minutes_layout = QHBoxLayout(minutes_row)
+        minutes_layout.setContentsMargins(0, 0, 0, 0)
+        minutes_layout.setSpacing(6)
+        minutes_layout.addWidget(self.minutes)
+        minutes_layout.addWidget(self.auto_minutes)
+        minutes_layout.addStretch(1)
+
         form = QFormLayout()
         form.addRow("Базовая ставка", self.base_investment)
-        form.addRow("Время экспирации (мин)", self.minutes)
+        form.addRow("Время экспирации (мин)", minutes_row)
         form.addRow("Макс. шагов", self.max_steps)
         form.addRow("Повторов серии", self.repeat_count)
         form.addRow("Мин. баланс", self.min_balance)
@@ -81,12 +97,14 @@ class FibonacciSettingsDialog(QDialog):
 
     def get_params(self) -> dict:
         symbol = str(self.params.get("symbol", ""))
-        m = int(self.minutes.value())
-        norm = normalize_sprint(symbol, m)
+        auto_minutes = bool(self.auto_minutes.isChecked())
+        raw_minutes = _minutes_from_timeframe(tf) if auto_minutes else int(self.minutes.value())
+        norm = normalize_sprint(symbol, raw_minutes)
         if norm is None:
-            norm = 5 if symbol == "BTCUSDT" else (1 if m < 3 else max(3, min(500, m)))
+            norm = 5 if symbol == "BTCUSDT" else (1 if raw_minutes < 3 else max(3, min(500, raw_minutes)))
         return {
             "minutes": int(norm),
+            "auto_minutes": auto_minutes,
             "base_investment": self.base_investment.value(),
             "max_steps": self.max_steps.value(),
             "repeat_count": self.repeat_count.value(),

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -90,6 +90,8 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
         timeframe = signal_data['timeframe']
         direction = signal_data['direction']
 
+        self._maybe_set_auto_minutes(timeframe)
+
         log = self.log or (lambda s: None)
 
         trade_key = self.build_trade_key(symbol, timeframe)

--- a/strategies/constants.py
+++ b/strategies/constants.py
@@ -24,4 +24,5 @@ DEFAULTS = {
     "classic_trade_buffer_sec": 10.0,
     "classic_min_time_before_next_sec": 180.0,
     "use_common_series": False,
+    "auto_minutes": False,
 }

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -99,6 +99,8 @@ class FibonacciStrategy(BaseTradingStrategy):
         symbol = signal_data['symbol']
         timeframe = signal_data['timeframe']
         direction = signal_data['direction']
+
+        self._maybe_set_auto_minutes(timeframe)
         trade_key = self.build_trade_key(symbol, timeframe)
 
         log = self.log or (lambda s: None)

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -84,6 +84,8 @@ class FixedStakeStrategy(BaseTradingStrategy):
         symbol = signal_data['symbol']
         timeframe = signal_data['timeframe']
         direction = signal_data['direction']
+
+        self._maybe_set_auto_minutes(timeframe)
        
         log = self.log or (lambda s: None)
         log(start_processing(symbol, "Fixed Stake"))

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -171,6 +171,8 @@ class MartingaleStrategy(BaseTradingStrategy):
         timeframe = signal_data["timeframe"]
         direction = signal_data["direction"]
 
+        self._maybe_set_auto_minutes(timeframe)
+
         log = self.log or (lambda s: None)
 
         trade_key = self.build_trade_key(symbol, timeframe)
@@ -201,6 +203,7 @@ class MartingaleStrategy(BaseTradingStrategy):
                 symbol = signal_data["symbol"]
                 timeframe = signal_data["timeframe"]
                 direction = signal_data["direction"]
+                self._maybe_set_auto_minutes(timeframe)
 
         # 4) К этому моменту:
         #    - нет активной серии

--- a/strategies/oscar_grind_base.py
+++ b/strategies/oscar_grind_base.py
@@ -76,6 +76,8 @@ class OscarGrindBaseStrategy(BaseTradingStrategy):
         symbol = signal_data['symbol']
         timeframe = signal_data['timeframe']
         direction = signal_data['direction']
+
+        self._maybe_set_auto_minutes(timeframe)
         trade_key = self.build_trade_key(symbol, timeframe)
 
         log = self.log or (lambda s: None)


### PR DESCRIPTION
## Summary
- add an auto sprint duration flag that syncs trade minutes with incoming signal timeframes
- expose an "Авто" toggle next to sprint duration inputs across the control dialog and settings dialogs
- store the auto duration preference in defaults so strategies keep the setting in templates and runtime updates

## Testing
- python -m compileall strategies gui

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938f37256a4832e91f5134438f2fc54)