### PR TITLE
Add step column to trade tables

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -742,6 +742,7 @@ class MainWindow(QWidget):
         indicator: str | None = None,
         series: str | None = None,
         expected_end_ts: float | None = None,
+        step: str | None = None,
     ):
         """Добавляет строку ожидания сделки."""
         duration = float(wait_seconds)
@@ -762,6 +763,7 @@ class MainWindow(QWidget):
             series=series,
             expected_end_ts=expected_end_ts,
             currency=self.account_currency,
+            step=step,
         )
 
     def add_trade_result(
@@ -780,6 +782,7 @@ class MainWindow(QWidget):
         account_mode: str | None = None,
         indicator: str | None = None,  # <= НОВОЕ
         series: str | None = None,
+        step: str | None = None,
         ):
         """Добавляет результат сделки в таблицу."""
         acc = account_mode or ("ДЕМО" if self.is_demo else "РЕАЛ")
@@ -801,6 +804,7 @@ class MainWindow(QWidget):
                 percent=int(percent),
                 account_mode=acc,
                 series=series,
+                step=step,
                 currency=self.account_currency,
             )
 
@@ -1063,6 +1067,7 @@ class MainWindow(QWidget):
         account_mode,
         indicator: str = "-",
         series: str | None = None,
+        step: str | None = None,
         bot=None,
     ):
         strat_label = "-"
@@ -1083,6 +1088,7 @@ class MainWindow(QWidget):
             account_mode=account_mode,
             indicator=indicator,
             series=series,
+            step=step,
         )
         # (при желании: дублируем в локальные таблицы окон стратегий)
 
@@ -1101,6 +1107,7 @@ class MainWindow(QWidget):
         account_mode,
         indicator: str = "-",
         series: str | None = None,
+        step: str | None = None,
         bot=None,
     ):
         strat_label = "-"
@@ -1121,4 +1128,5 @@ class MainWindow(QWidget):
             account_mode=account_mode,
             indicator=indicator,
             series=series,
+            step=step,
         )

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -100,7 +100,7 @@ class StrategyControlDialog(QWidget):
 
         # ---------- ТАБЛИЦА СДЕЛОК (справа) ----------
         self.trades_table = QTableWidget(self)
-        self.trades_table.setColumnCount(12)
+        self.trades_table.setColumnCount(13)
         self.trades_table.setHorizontalHeaderLabels(
             [
                 "Время сигнала",  # 0
@@ -108,13 +108,14 @@ class StrategyControlDialog(QWidget):
                 "Пара",  # 2
                 "ТФ",  # 3
                 "Серия",  # 4
-                "Индикатор",  # 5  (если не прилетит — ставим "—")
-                "Направление",  # 6
-                "Ставка",  # 7
-                "Время",  # 8
-                "Процент",  # 9
-                "P/L",  # 10
-                "Счёт",  # 11
+                "Шаг",  # 5
+                "Индикатор",  # 6  (если не прилетит — ставим "—")
+                "Направление",  # 7
+                "Ставка",  # 8
+                "Время",  # 9
+                "Процент",  # 10
+                "P/L",  # 11
+                "Счёт",  # 12
             ]
         )
         hdr = self.trades_table.horizontalHeader()
@@ -728,6 +729,7 @@ class StrategyControlDialog(QWidget):
         indicator: str | None = None,
         series: str | None = None,
         expected_end_ts: float | None = None,  # ⬅️ НОВОЕ: абсолютный дедлайн
+        step: str | None = None,
     ):
         """
         Добавляем жёлтую строку с обратным отсчётом в ПРАВОЙ таблице диалога.
@@ -770,17 +772,18 @@ class StrategyControlDialog(QWidget):
             symbol,  # 2 Пара
             timeframe,  # 3 ТФ
             series or "—",  # 4 Серия
-            ind_txt,  # 5 Индикатор
-            dir_text,  # 6 Направление
-            self._fmt_money(stake, ccy),  # 7 Ставка
-            duration_txt,  # 8 Время
-            f"{percent}%",  # 9 %
-            f"Ожидание ({_fmt_left(left_now)})",  # 10 P/L
-            account_txt,  # 11 Счёт
+            step or "—",  # 5 Шаг
+            ind_txt,  # 6 Индикатор
+            dir_text,  # 7 Направление
+            self._fmt_money(stake, ccy),  # 8 Ставка
+            duration_txt,  # 9 Время
+            f"{percent}%",  # 10 %
+            f"Ожидание ({_fmt_left(left_now)})",  # 11 P/L
+            account_txt,  # 12 Счёт
         ]
         for col, v in enumerate(vals):
             it = QTableWidgetItem(str(v))
-            if col in (6, 10):
+            if col in (7, 11):
                 it.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             self.trades_table.setItem(row, col, it)
 
@@ -803,7 +806,7 @@ class StrategyControlDialog(QWidget):
             if not isinstance(cur_row, int) or cur_row >= self.trades_table.rowCount():
                 timer.stop()
                 return
-            item = self.trades_table.item(cur_row, 10)
+            item = self.trades_table.item(cur_row, 11)
             if item:
                 item.setText(f"Ожидание ({_fmt_left(left)})")
             if left <= 0:
@@ -835,6 +838,7 @@ class StrategyControlDialog(QWidget):
             "placed_at": placed_at,
             "wait_seconds": float(wait_seconds),
             "series": series,
+            "step": step,
         }
 
         if was_sort:
@@ -855,6 +859,7 @@ class StrategyControlDialog(QWidget):
         account_mode: str | None = None,
         indicator: str | None = None,
         series: str | None = None,
+        step: str | None = None,
     ):
         """
         Обновляем/добавляем зелёную/красную/серую строку по результату.
@@ -873,6 +878,7 @@ class StrategyControlDialog(QWidget):
         place_time = placed_at
         duration_txt = ""
         series_txt = series or "—"
+        step_txt = step or "—"
         if trade_id and trade_id in self._pending_rows:
             info = self._pending_rows.pop(trade_id, {})
             timer = info.get("timer")
@@ -889,6 +895,7 @@ class StrategyControlDialog(QWidget):
                 place_time = info.get("placed_at", place_time)
                 duration_txt = f"{int(round(info.get('wait_seconds', 0.0) / 60))} мин"
                 series_txt = info.get("series", series_txt) or "—"
+                step_txt = info.get("step", step_txt) or "—"
 
         was_sort = self.trades_table.isSortingEnabled()
         if was_sort:
@@ -915,17 +922,18 @@ class StrategyControlDialog(QWidget):
             symbol,  # 2
             timeframe,  # 3
             series_txt,  # 4
-            ind_txt,  # 5
-            dir_text,  # 6
-            self._fmt_money(stake, ccy),  # 7
-            duration_txt,  # 8
-            f"{percent}%",  # 9
-            fmt_pl(profit, ccy),  # 10
-            account_txt,  # 11
+            step_txt,  # 5
+            ind_txt,  # 6
+            dir_text,  # 7
+            self._fmt_money(stake, ccy),  # 8
+            duration_txt,  # 9
+            f"{percent}%",  # 10
+            fmt_pl(profit, ccy),  # 11
+            account_txt,  # 12
         ]
         for col, v in enumerate(vals):
             item = QTableWidgetItem(str(v))
-            if col in (6, 10):
+            if col in (7, 11):
                 item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             self.trades_table.setItem(row_to_update, col, item)
 

--- a/gui/trades_table_widget.py
+++ b/gui/trades_table_widget.py
@@ -14,15 +14,16 @@ class TradesTableWidget(QTableWidget):
       [1] Время ставки
       [2] Стратегия
       [3] Серия
-      [4] Индикатор        <-- ОТ КОГО ПРИШЁЛ СИГНАЛ
-      [5] Валютная пара
-      [6] ТФ
-      [7] Направление
-      [8] Ставка
-      [9] Время
-      [10] Процент
-      [11] P/L
-      [12] Счёт
+      [4] Шаг
+      [5] Индикатор        <-- ОТ КОГО ПРИШЁЛ СИГНАЛ
+      [6] Валютная пара
+      [7] ТФ
+      [8] Направление
+      [9] Ставка
+      [10] Время
+      [11] Процент
+      [12] P/L
+      [13] Счёт
     """
 
     COLS = [
@@ -30,6 +31,7 @@ class TradesTableWidget(QTableWidget):
         "Время ставки",
         "Стратегия",
         "Серия",
+        "Шаг",
         "Индикатор",
         "Валютная пара",
         "ТФ",
@@ -77,6 +79,7 @@ class TradesTableWidget(QTableWidget):
         series: str | None = None,
         expected_end_ts: float | None = None,
         currency: str | None = None,
+        step: str | None = None,
     ):
         """Добавляет строку ожидания с таймером."""
         from time import time as _now
@@ -109,6 +112,7 @@ class TradesTableWidget(QTableWidget):
             placed_at,
             strategy or "-",
             series or "—",
+            step or "—",
             indicator or "-",
             symbol,
             timeframe,
@@ -121,7 +125,7 @@ class TradesTableWidget(QTableWidget):
         ]
         for col, val in enumerate(values):
             it = QTableWidgetItem(str(val))
-            if col in (7, 11):  # выравнивание Направление, P/L по центру
+            if col in (8, 12):  # выравнивание Направление, P/L по центру
                 it.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             self.setItem(row, col, it)
 
@@ -144,7 +148,7 @@ class TradesTableWidget(QTableWidget):
             if not isinstance(cur_row, int) or cur_row >= self.rowCount():
                 timer.stop()
                 return
-            item = self.item(cur_row, 11)
+            item = self.item(cur_row, 12)
             if item:
                 item.setText(f"Ожидание ({_fmt_left(left)})")
             if left <= 0:
@@ -167,6 +171,7 @@ class TradesTableWidget(QTableWidget):
             "timer": timer,
             "expected_end_ts": float(expected_end_ts),
             "series": series,
+            "step": step,
         }
 
     def set_result(
@@ -185,11 +190,11 @@ class TradesTableWidget(QTableWidget):
             return
         row = self._row_by_trade[trade_id]
 
-        pl_item = self.item(row, 11)
+        pl_item = self.item(row, 12)
         if pl_item is None:
             pl_item = QTableWidgetItem()
             pl_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
-            self.setItem(row, 11, pl_item)
+            self.setItem(row, 12, pl_item)
 
         if profit is None:
             pl_item.setText("неизв.")

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -481,6 +481,7 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
                 wait_seconds = float(wait_seconds)
 
             # Уведомляем о pending сделке
+            step_label = self.format_step_label(step, max_steps)
             self._notify_pending_trade(
                 trade_id,
                 symbol,
@@ -493,6 +494,7 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
                 expected_end_ts,
                 signal_at=signal_at_str,
                 series_label=series_label,
+                step_label=step_label,
             )
             self._register_pending_trade(trade_id, symbol, timeframe)
 
@@ -510,6 +512,7 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
                 account_mode=account_mode,
                 indicator=self._last_indicator,
                 series_label=series_label,
+                step_label=step_label,
             )
 
             # === Парлей-логика AntiMartingale ===
@@ -605,6 +608,7 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
         *,
         signal_at: Optional[str] = None,
         series_label: Optional[str] = None,
+        step_label: Optional[str] = None,
     ):
         """Уведомляет о pending сделке"""
         placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
@@ -628,6 +632,7 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
                     indicator=self._last_indicator,
                     expected_end_ts=expected_end_ts,
                     series=series_label,
+                    step=step_label,
                 )
             except Exception:
                 pass

--- a/strategies/base_trading_strategy.py
+++ b/strategies/base_trading_strategy.py
@@ -180,6 +180,22 @@ class BaseTradingStrategy(StrategyBase):
         current = max(1, min(total, total - remaining_int + 1))
         return f"{current}/{total}"
 
+    def format_step_label(
+        self, step_idx: int | None, max_steps: int | None
+    ) -> str | None:
+        """Возвращает строку "Текущий/Максимум" для шага серии."""
+
+        try:
+            cur = int(step_idx) if step_idx is not None else None
+            total = int(max_steps) if max_steps is not None else None
+        except Exception:
+            return None
+
+        if cur is None or total is None or total <= 0 or cur < 0:
+            return None
+
+        return f"{min(cur + 1, total)}/{total}"
+
     def get_planned_stake(self, trade_key: str) -> float | None:
         """Возвращает последнюю рассчитанную ставку для ключа сделки."""
 
@@ -423,6 +439,7 @@ class BaseTradingStrategy(StrategyBase):
         account_mode: Optional[str],
         indicator: str,
         series_label: str | None = None,
+        step_label: str | None = None,
     ) -> Optional[float]:
         """Ожидание результата сделки"""
         self._status("ожидание результата")
@@ -453,6 +470,7 @@ class BaseTradingStrategy(StrategyBase):
                     account_mode=account_mode,
                     indicator=indicator,
                     series=series_label,
+                    step=step_label,
                 )
             except Exception:
                 pass

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -401,6 +401,7 @@ class FibonacciStrategy(BaseTradingStrategy):
             else:
                 wait_seconds = float(wait_seconds)
 
+            step_label = self.format_step_label(step_idx, max_steps)
             self._notify_pending_trade(
                 trade_id,
                 symbol,
@@ -413,6 +414,7 @@ class FibonacciStrategy(BaseTradingStrategy):
                 expected_end_ts,
                 signal_at=signal_at_str,
                 series_label=series_label,
+                step_label=step_label,
             )
             self._register_pending_trade(trade_id, symbol, timeframe)
 
@@ -430,6 +432,7 @@ class FibonacciStrategy(BaseTradingStrategy):
                 account_mode=account_mode,
                 indicator=self._last_indicator,
                 series_label=series_label,
+                step_label=step_label,
             )
 
             step_idx += 1
@@ -544,6 +547,7 @@ class FibonacciStrategy(BaseTradingStrategy):
         *,
         signal_at: Optional[str] = None,
         series_label: Optional[str] = None,
+        step_label: Optional[str] = None,
     ):
         """Уведомляет о pending сделке"""
         placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
@@ -567,6 +571,7 @@ class FibonacciStrategy(BaseTradingStrategy):
                     indicator=self._last_indicator,
                     expected_end_ts=expected_end_ts,
                     series=series_label,
+                    step=step_label,
                 )
             except Exception:
                 pass

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -487,6 +487,7 @@ class MartingaleStrategy(BaseTradingStrategy):
                 wait_seconds = float(wait_seconds)
 
             # Уведомляем о pending сделке
+            step_label = self.format_step_label(step, max_steps)
             self._notify_pending_trade(
                 trade_id,
                 symbol,
@@ -499,6 +500,7 @@ class MartingaleStrategy(BaseTradingStrategy):
                 expected_end_ts,
                 signal_at=signal_at_str,
                 series_label=series_label,
+                step_label=step_label,
             )
             self._register_pending_trade(trade_id, symbol, timeframe)
 
@@ -516,6 +518,7 @@ class MartingaleStrategy(BaseTradingStrategy):
                 account_mode=account_mode,
                 indicator=self._last_indicator,
                 series_label=series_label,
+                step_label=step_label,
             )
 
             # Обрабатываем результат
@@ -597,6 +600,7 @@ class MartingaleStrategy(BaseTradingStrategy):
         *,
         signal_at: Optional[str] = None,
         series_label: Optional[str] = None,
+        step_label: Optional[str] = None,
     ):
         """Уведомляет о pending сделке"""
         placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
@@ -620,6 +624,7 @@ class MartingaleStrategy(BaseTradingStrategy):
                     indicator=self._last_indicator,
                     expected_end_ts=expected_end_ts,
                     series=series_label,
+                    step=step_label,
                 )
             except Exception:
                 pass

--- a/strategies/oscar_grind_base.py
+++ b/strategies/oscar_grind_base.py
@@ -334,6 +334,7 @@ class OscarGrindBaseStrategy(BaseTradingStrategy):
             trade_seconds, expected_end_ts = self._calculate_trade_duration(symbol)
             wait_seconds = self.params.get("result_wait_s", trade_seconds)
 
+            step_label = self.format_step_label(step_idx, max_steps)
             self._notify_pending_trade(
                 trade_id,
                 symbol,
@@ -346,6 +347,7 @@ class OscarGrindBaseStrategy(BaseTradingStrategy):
                 expected_end_ts,
                 signal_at=signal_at_str,
                 series_label=series_label,
+                step_label=step_label,
             )
             self._register_pending_trade(trade_id, symbol, timeframe)
 
@@ -362,6 +364,7 @@ class OscarGrindBaseStrategy(BaseTradingStrategy):
                 account_mode=account_mode,
                 indicator=self._last_indicator,
                 series_label=series_label,
+                step_label=step_label,
             )
 
             if profit is None:
@@ -493,6 +496,7 @@ class OscarGrindBaseStrategy(BaseTradingStrategy):
         *,
         signal_at: Optional[str] = None,
         series_label: Optional[str] = None,
+        step_label: Optional[str] = None,
     ):
         """Уведомляет о pending сделке"""
         placed_at_str = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
@@ -516,6 +520,7 @@ class OscarGrindBaseStrategy(BaseTradingStrategy):
                     indicator=self._last_indicator,
                     expected_end_ts=expected_end_ts,
                     series=series_label,
+                    step=step_label,
                 )
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- add a step column next to series in the main and bot trade tables
- propagate step labels from strategies to UI trade events
- track step information across pending and result rows

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a642785fc832ea0bbed8f9f51e476)