### PR TITLE
Add shared payout provider for bots

### DIFF
--- a/core/payout_provider.py
+++ b/core/payout_provider.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+from core.intrade_api_async import get_current_percent as _fetch_percent
+
+
+@dataclass
+class _PayoutEntry:
+    value: Optional[int] = None
+    timestamp: float = 0.0
+    in_flight: asyncio.Task | None = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+_CACHE: Dict[Tuple[str, str, str, str, str], _PayoutEntry] = {}
+_DEFAULT_TTL = 1.0
+
+
+def _build_key(
+    investment: float | int | str,
+    option: str,
+    minutes: int | str,
+    account_ccy: str,
+    trade_type: str,
+) -> Tuple[str, str, str, str, str]:
+    return (
+        str(option).upper(),
+        str(minutes),
+        str(account_ccy).upper(),
+        str(trade_type).lower(),
+        str(investment),
+    )
+
+
+async def _run_fetch(
+    key: Tuple[str, str, str, str, str],
+    entry: _PayoutEntry,
+    client,
+    investment: float | int | str,
+    option: str,
+    minutes: int | str,
+    account_ccy: str,
+    trade_type: str,
+) -> Optional[int]:
+    try:
+        value = await _fetch_percent(
+            client,
+            investment=investment,
+            option=option,
+            minutes=minutes,
+            account_ccy=account_ccy,
+            trade_type=trade_type,
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        value = None
+
+    async with entry.lock:
+        entry.value = value
+        entry.timestamp = time.monotonic()
+        entry.in_flight = None
+    return value
+
+
+async def get_cached_payout(
+    client,
+    *,
+    investment: float | int | str,
+    option: str,
+    minutes: int | str = 1,
+    account_ccy: str = "RUB",
+    trade_type: str = "Sprint",
+    cache_ttl: float = _DEFAULT_TTL,
+) -> Optional[int]:
+    """
+    Вернуть текущий payout с кешированием между запросами разных ботов.
+
+    Запрос к API выполняется только если данные устарели или отсутствуют.
+    Пока никто не запрашивает payout, обращений к серверу нет.
+    """
+
+    key = _build_key(investment, option, minutes, account_ccy, trade_type)
+    entry = _CACHE.get(key)
+    if entry is None:
+        entry = _PayoutEntry()
+        _CACHE[key] = entry
+
+    async with entry.lock:
+        now = time.monotonic()
+        if entry.value is not None and (now - entry.timestamp) < max(cache_ttl, 0.0):
+            return entry.value
+
+        if entry.in_flight is None:
+            entry.in_flight = asyncio.create_task(
+                _run_fetch(
+                    key,
+                    entry,
+                    client,
+                    investment,
+                    option,
+                    minutes,
+                    account_ccy,
+                    trade_type,
+                )
+            )
+        task = entry.in_flight
+
+    return await task

--- a/strategies/antimartin.py
+++ b/strategies/antimartin.py
@@ -9,7 +9,8 @@ from strategies.base_trading_strategy import BaseTradingStrategy, _minutes_from_
 from strategies.constants import MOSCOW_TZ
 from core.time_utils import format_local_time
 from core.money import format_amount
-from core.intrade_api_async import is_demo_account, get_current_percent
+from core.intrade_api_async import is_demo_account
+from core.payout_provider import get_cached_payout
 from strategies.log_messages import (
     repeat_count_empty,
     series_already_active,
@@ -189,7 +190,7 @@ class AntiMartingaleStrategy(BaseTradingStrategy):
         account_ccy = self._anchor_ccy
 
         try:
-            pct = await get_current_percent(
+            pct = await get_cached_payout(
                 self.http_client,
                 investment=stake,
                 option=symbol,

--- a/strategies/base_trading_strategy.py
+++ b/strategies/base_trading_strategy.py
@@ -6,11 +6,11 @@ from zoneinfo import ZoneInfo
 from core.http_async import HttpClient
 from core.intrade_api_async import (
     get_balance_info,
-    get_current_percent,
     place_trade,
     check_trade_result,
     is_demo_account,
 )
+from core.payout_provider import get_cached_payout
 from core.signal_waiter import wait_for_signal_versioned
 from core.money import format_amount
 from core.policy import normalize_sprint
@@ -493,7 +493,7 @@ class BaseTradingStrategy(StrategyBase):
         account_ccy = self._anchor_ccy
        
         # Проверка выплаты
-        pct = await get_current_percent(
+        pct = await get_cached_payout(
             self.http_client,
             investment=stake,
             option=symbol,

--- a/strategies/fibonacci.py
+++ b/strategies/fibonacci.py
@@ -11,8 +11,8 @@ from core.money import format_amount
 from core.intrade_api_async import (
     is_demo_account,
     get_balance_info,
-    get_current_percent,
 )
+from core.payout_provider import get_cached_payout
 from core.time_utils import format_local_time
 from strategies.log_messages import (
     repeat_count_empty,
@@ -119,7 +119,7 @@ class FibonacciStrategy(BaseTradingStrategy):
         account_ccy = self._anchor_ccy
 
         try:
-            pct = await get_current_percent(
+            pct = await get_cached_payout(
                 self.http_client,
                 investment=stake,
                 option=symbol,

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -11,8 +11,8 @@ from core.money import format_amount
 from core.intrade_api_async import (
     is_demo_account,
     get_balance_info,
-    get_current_percent,
 )
+from core.payout_provider import get_cached_payout
 from core.time_utils import format_local_time
 from strategies.log_messages import (
     start_processing,
@@ -108,7 +108,7 @@ class FixedStakeStrategy(BaseTradingStrategy):
     async def _is_payout_low_now(self, symbol: str, stake: float) -> Optional[int]:
         min_pct = int(self.params.get("min_percent", 70))
         try:
-            pct = await get_current_percent(
+            pct = await get_cached_payout(
                 self.http_client,
                 investment=stake,
                 option=symbol,

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -9,7 +9,8 @@ from strategies.base_trading_strategy import BaseTradingStrategy, _minutes_from_
 from strategies.constants import MOSCOW_TZ
 from core.time_utils import format_local_time
 from core.money import format_amount
-from core.intrade_api_async import is_demo_account, get_current_percent
+from core.intrade_api_async import is_demo_account
+from core.payout_provider import get_cached_payout
 from strategies.log_messages import (
     repeat_count_empty,
     series_already_active,
@@ -161,7 +162,7 @@ class MartingaleStrategy(BaseTradingStrategy):
         account_ccy = self._anchor_ccy
 
         try:
-            pct = await get_current_percent(
+            pct = await get_cached_payout(
                 self.http_client,
                 investment=stake,
                 option=symbol,

--- a/strategies/oscar_grind_base.py
+++ b/strategies/oscar_grind_base.py
@@ -9,7 +9,8 @@ from strategies.base_trading_strategy import BaseTradingStrategy, _minutes_from_
 from strategies.constants import MOSCOW_TZ
 from core.time_utils import format_local_time
 from core.money import format_amount
-from core.intrade_api_async import is_demo_account, get_current_percent
+from core.intrade_api_async import is_demo_account
+from core.payout_provider import get_cached_payout
 from strategies.log_messages import (
     repeat_count_empty,
     signal_not_actual_for_placement,
@@ -162,7 +163,7 @@ class OscarGrindBaseStrategy(BaseTradingStrategy):
         account_ccy = self._anchor_ccy
 
         try:
-            pct = await get_current_percent(
+            pct = await get_cached_payout(
                 self.http_client,
                 investment=stake,
                 option=symbol,


### PR DESCRIPTION
## Summary
- add a shared cached payout provider so multiple bots reuse payout requests instead of polling separately
- update all strategies to read payout values through the shared provider

## Testing
- python -m compileall core strategies

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b9410e488832eba3b5f3a2aa7982f)