### PR TITLE
Improve bot status updates and FixedStake timing

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -477,6 +477,12 @@ class MainWindow(QWidget):
                 f"🤖 Создан бот: {strategy_label} [{symbol} {timeframe}]. Откройте настройки, чтобы запустить."
             )
 
+            # Автоматически открываем окно управления, чтобы задать параметры и запустить
+            try:
+                self.open_strategy_control_dialog(bot)
+            except Exception:
+                pass
+
         asyncio.create_task(_spawn_bot())
 
     def open_strategy_control_dialog(self, bot):

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -518,6 +518,10 @@ class StrategyControlDialog(QWidget):
                 self.main.bot_logs[self.bot].clear()
                 self.main.bot_trade_history[self.bot].clear()
                 self.main.reset_bot(self.bot)
+                try:
+                    self.main._set_bot_status(self.bot, "ожидание сигнала")
+                except Exception:
+                    pass
                 self.bot.start()
                 self._add_log(ts("🚀 Старт стратегии."))
             elif paused:

--- a/strategies/base_trading_strategy.py
+++ b/strategies/base_trading_strategy.py
@@ -663,7 +663,10 @@ class BaseTradingStrategy(StrategyBase):
         """Запуск стратегии"""
         self._running = True
         log = self.log or (lambda s: None)
-        
+
+        # Сразу помечаем ожидание, чтобы UI обновился до появления первого статуса
+        self._status("ожидание сигнала")
+
         # Инициализация аккаунта
         await self._initialize_account()
         

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -38,7 +38,8 @@ FIXED_DEFAULTS = {
     "wait_on_low_percent": 1,
     "signal_timeout_sec": 3600,
     "account_currency": "RUB",
-    "result_wait_s": 60.0,
+    # Для фиксированной ставки ждём результат всю длительность сделки (classic/sprint)
+    "result_wait_s": None,
     "grace_delay_sec": 30.0,
     "trade_type": "classic",
     "allow_parallel_trades": True,
@@ -376,8 +377,12 @@ class FixedStakeStrategy(BaseTradingStrategy):
             self._placed_trades_total += 1
 
             trade_seconds, expected_end_ts = self._calculate_trade_duration(symbol)
-            wait_seconds = self.params.get("result_wait_s")
-            wait_seconds = trade_seconds if wait_seconds is None else float(wait_seconds)
+            wait_seconds_cfg = self.params.get("result_wait_s")
+            wait_seconds = (
+                trade_seconds
+                if wait_seconds_cfg is None or float(wait_seconds_cfg) <= 0
+                else float(wait_seconds_cfg)
+            )
 
             signal_at_str = signal_data.get("signal_time_str") or format_local_time(signal_data["timestamp"])
             series_label = self.format_series_label(trade_key, series_left=series_left)


### PR DESCRIPTION
## Summary
- show waiting status as soon as a bot starts and auto-open the control dialog after creation
- emit strategy status immediately on run to keep the main table in sync
- let FixedStakeStrategy wait for the full trade duration unless overridden

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bb25d5190832eaa8bd9a78e727aa2)