### PR TITLE
Enable common series checkbox by default

### DIFF
--- a/gui/settings_antimartin.py
+++ b/gui/settings_antimartin.py
@@ -62,7 +62,7 @@ class AntimartinSettingsDialog(QDialog):
 
         self.common_series = QCheckBox()
         self.common_series.setChecked(
-            bool(self.params.get("use_common_series", False))
+            bool(self.params.get("use_common_series", True))
         )
         common_series_label = QLabel("Общая серия для всех сигналов")
         common_series_label.mousePressEvent = (

--- a/gui/settings_fibonacci.py
+++ b/gui/settings_fibonacci.py
@@ -61,7 +61,7 @@ class FibonacciSettingsDialog(QDialog):
 
         self.common_series = QCheckBox()
         self.common_series.setChecked(
-            bool(self.params.get("use_common_series", False))
+            bool(self.params.get("use_common_series", True))
         )
         common_series_label = QLabel("Общая серия для всех сигналов")
         common_series_label.mousePressEvent = (

--- a/gui/settings_fixed.py
+++ b/gui/settings_fixed.py
@@ -57,7 +57,7 @@ class FixedSettingsDialog(QDialog):
 
         self.common_series = QCheckBox()
         self.common_series.setChecked(
-            bool(self.params.get("use_common_series", False))
+            bool(self.params.get("use_common_series", True))
         )
         common_series_label = QLabel("Общая серия для всех сигналов")
         common_series_label.mousePressEvent = (

--- a/gui/settings_martingale.py
+++ b/gui/settings_martingale.py
@@ -70,7 +70,7 @@ class MartingaleSettingsDialog(QDialog):
 
         self.common_series = QCheckBox()
         self.common_series.setChecked(
-            bool(self.params.get("use_common_series", False))
+            bool(self.params.get("use_common_series", True))
         )
         common_series_label = QLabel("Общая серия для всех сигналов")
         common_series_label.mousePressEvent = (

--- a/gui/settings_oscar_grind.py
+++ b/gui/settings_oscar_grind.py
@@ -75,7 +75,7 @@ class OscarGrindSettingsDialog(QDialog):
 
         self.common_series = QCheckBox()
         self.common_series.setChecked(
-            bool(self.params.get("use_common_series", False))
+            bool(self.params.get("use_common_series", True))
         )
         common_series_label = QLabel("Общая серия для всех сигналов")
         common_series_label.mousePressEvent = (

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -220,7 +220,7 @@ class StrategyControlDialog(QWidget):
         self.parallel_trades = QCheckBox()
         self.parallel_trades.setChecked(bool(getv("allow_parallel_trades", True)))
         self.common_series = QCheckBox()
-        self.common_series.setChecked(bool(getv("use_common_series", False)))
+        self.common_series.setChecked(bool(getv("use_common_series", True)))
 
         if strategy_key in ("oscar_grind_1", "oscar_grind_2"):
             self.minutes = QSpinBox()


### PR DESCRIPTION
## Summary
- default the "Общая серия для всех сигналов" checkbox to checked across strategy settings dialogs
- align the strategy control dialog to initialize the common series option as enabled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bb3ddc010832eac40b8e3422fd40d)