### PR TITLE
Remove common series option for fixed stake

### DIFF
--- a/gui/settings_fixed.py
+++ b/gui/settings_fixed.py
@@ -55,15 +55,6 @@ class FixedSettingsDialog(QDialog):
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
 
-        self.common_series = QCheckBox()
-        self.common_series.setChecked(
-            bool(self.params.get("use_common_series", False))
-        )
-        common_series_label = QLabel("Общая серия для всех сигналов")
-        common_series_label.mousePressEvent = (
-            lambda event: self.common_series.toggle()
-        )
-
         minutes_row = QWidget()
         minutes_layout = QHBoxLayout(minutes_row)
         minutes_layout.setContentsMargins(0, 0, 0, 0)
@@ -79,7 +70,6 @@ class FixedSettingsDialog(QDialog):
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
         form.addRow(parallel_label, self.parallel_trades)
-        form.addRow(common_series_label, self.common_series)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -105,6 +95,5 @@ class FixedSettingsDialog(QDialog):
             "min_balance": self.min_balance.value(),
             "min_percent": self.min_percent.value(),
             "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
-            "use_common_series": bool(self.common_series.isChecked()),
         }
 

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -219,8 +219,10 @@ class StrategyControlDialog(QWidget):
 
         self.parallel_trades = QCheckBox()
         self.parallel_trades.setChecked(bool(getv("allow_parallel_trades", True)))
-        self.common_series = QCheckBox()
-        self.common_series.setChecked(bool(getv("use_common_series", False)))
+        self.common_series = None
+        if strategy_key != "fixed":
+            self.common_series = QCheckBox()
+            self.common_series.setChecked(bool(getv("use_common_series", False)))
 
         if strategy_key in ("oscar_grind_1", "oscar_grind_2"):
             self.minutes = QSpinBox()
@@ -333,11 +335,11 @@ class StrategyControlDialog(QWidget):
 
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
-        common_series_label = QLabel("Общая серия для всех сигналов")
-        common_series_label.mousePressEvent = lambda event: self.common_series.toggle()
-
         form.addRow(parallel_label, self.parallel_trades)
-        form.addRow(common_series_label, self.common_series)
+        if self.common_series is not None:
+            common_series_label = QLabel("Общая серия для всех сигналов")
+            common_series_label.mousePressEvent = lambda event: self.common_series.toggle()
+            form.addRow(common_series_label, self.common_series)
 
         def _update_minutes_enabled(text: str):
             if self.minutes is not None:
@@ -613,7 +615,9 @@ class StrategyControlDialog(QWidget):
                 new_params["minutes"] = int(norm)
         new_params["trade_type"] = trade_type
         new_params["allow_parallel_trades"] = self.parallel_trades.isChecked()
-        new_params["use_common_series"] = self.common_series.isChecked()
+        new_params["use_common_series"] = (
+            self.common_series.isChecked() if self.common_series is not None else False
+        )
         return new_params
 
     def apply_settings(self):


### PR DESCRIPTION
## Summary
- remove the common-series checkbox from the fixed stake settings and default the option to off
- keep fixed stake trade keys separate from other signals and report a constant single step per trade

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bb603984c832e838e59ada5380473)