### PR TITLE
Remove common series option for fixed stake strategy

### DIFF
--- a/gui/settings_fixed.py
+++ b/gui/settings_fixed.py
@@ -55,15 +55,6 @@ class FixedSettingsDialog(QDialog):
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
 
-        self.common_series = QCheckBox()
-        self.common_series.setChecked(
-            bool(self.params.get("use_common_series", True))
-        )
-        common_series_label = QLabel("Общая серия для всех сигналов")
-        common_series_label.mousePressEvent = (
-            lambda event: self.common_series.toggle()
-        )
-
         minutes_row = QWidget()
         minutes_layout = QHBoxLayout(minutes_row)
         minutes_layout.setContentsMargins(0, 0, 0, 0)
@@ -79,7 +70,6 @@ class FixedSettingsDialog(QDialog):
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
         form.addRow(parallel_label, self.parallel_trades)
-        form.addRow(common_series_label, self.common_series)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -105,6 +95,6 @@ class FixedSettingsDialog(QDialog):
             "min_balance": self.min_balance.value(),
             "min_percent": self.min_percent.value(),
             "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
-            "use_common_series": bool(self.common_series.isChecked()),
+            "use_common_series": False,
         }
 

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -221,6 +221,9 @@ class StrategyControlDialog(QWidget):
         self.parallel_trades.setChecked(bool(getv("allow_parallel_trades", True)))
         self.common_series = QCheckBox()
         self.common_series.setChecked(bool(getv("use_common_series", True)))
+        if strategy_key == "fixed":
+            self.common_series.setChecked(False)
+            self.common_series.setEnabled(False)
 
         if strategy_key in ("oscar_grind_1", "oscar_grind_2"):
             self.minutes = QSpinBox()
@@ -333,11 +336,12 @@ class StrategyControlDialog(QWidget):
 
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
-        common_series_label = QLabel("Общая серия для всех сигналов")
-        common_series_label.mousePressEvent = lambda event: self.common_series.toggle()
 
         form.addRow(parallel_label, self.parallel_trades)
-        form.addRow(common_series_label, self.common_series)
+        if strategy_key != "fixed":
+            common_series_label = QLabel("Общая серия для всех сигналов")
+            common_series_label.mousePressEvent = lambda event: self.common_series.toggle()
+            form.addRow(common_series_label, self.common_series)
 
         def _update_minutes_enabled(text: str):
             if self.minutes is not None:
@@ -613,7 +617,7 @@ class StrategyControlDialog(QWidget):
                 new_params["minutes"] = int(norm)
         new_params["trade_type"] = trade_type
         new_params["allow_parallel_trades"] = self.parallel_trades.isChecked()
-        new_params["use_common_series"] = self.common_series.isChecked()
+        new_params["use_common_series"] = False if strategy_key == "fixed" else self.common_series.isChecked()
         return new_params
 
     def apply_settings(self):
@@ -695,7 +699,11 @@ class StrategyControlDialog(QWidget):
                 self.double_entry.setChecked(bool(v))
             elif k == "allow_parallel_trades" and hasattr(self, "parallel_trades"):
                 self.parallel_trades.setChecked(bool(v))
-            elif k == "use_common_series" and hasattr(self, "common_series"):
+            elif (
+                k == "use_common_series"
+                and hasattr(self, "common_series")
+                and self.strategy_key != "fixed"
+            ):
                 self.common_series.setChecked(bool(v))
 
     def apply_template(self):


### PR DESCRIPTION
## Summary
- remove the "common series" checkbox from the fixed stake settings dialog and force the parameter to false
- hide the common series control in the strategy control dialog when configuring the fixed strategy
- ensure fixed stake strategies always use separate series steps regardless of templates

## Testing
- python -m compileall gui strategies


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bb72aabbc832e972ecb0424959c8b)