### PR TITLE
Align default series handling with UI

### DIFF
--- a/strategies/constants.py
+++ b/strategies/constants.py
@@ -23,6 +23,8 @@ DEFAULTS = {
     "classic_signal_max_age_sec": 170.0,
     "classic_trade_buffer_sec": 10.0,
     "classic_min_time_before_next_sec": 180.0,
-    "use_common_series": False,
+    # По умолчанию объединяем серию для всех сигналов, чтобы UI и стартовые
+    # параметры стратегии были согласованы (чекбокс включён).
+    "use_common_series": True,
     "auto_minutes": False,
 }


### PR DESCRIPTION
## Summary
- set `use_common_series` default to true so strategies start with a shared series by default
- add inline comment to document alignment between defaults and UI checkbox state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c19405ec0832e8292bfec827f9259)