### PR TITLE
Increase sprint signal tolerance window to 10 seconds

### DIFF
--- a/strategies/base_trading_strategy.py
+++ b/strategies/base_trading_strategy.py
@@ -311,9 +311,8 @@ class BaseTradingStrategy(StrategyBase):
         """Проверяет актуальность сигнала для sprint-торгов"""
         signal_timestamp = signal_data['timestamp']
         signal_age = (current_time - signal_timestamp).total_seconds()
-        
-        # 🔴 МЕНЯЕМ: максимальный возраст 5 секунд вместо 55
-        max_signal_age = 5.0  # Всего 5 секунд!
+
+        max_signal_age = SPRINT_SIGNAL_MAX_AGE_SEC
         
         if signal_age > max_signal_age:
             return False, f"сигналу {signal_age:.1f}с > {max_signal_age}с"
@@ -638,15 +637,15 @@ class BaseTradingStrategy(StrategyBase):
             return int(direction), int(ver), meta
 
     def _max_signal_age_seconds(self) -> float:
-        """Максимальный возраст сигнала. Для sprint — жёсткий лимит 5.0s."""
+        """Максимальный возраст сигнала. Для sprint — жёсткий лимит 10.0s."""
         # базовые значения (взятые из констант)
         base = 0.0
         if self._trade_type == "classic":
             base = CLASSIC_SIGNAL_MAX_AGE_SEC
         elif self._trade_type == "sprint":
-            # Жёстко ограничиваем sprint до 5 секунд — чтобы сигналы старше 5с
+            # Жёстко ограничиваем sprint, чтобы сигналы старше лимита
             # не попадали в слушатель и не создавали спам-логи.
-            return 5.0
+            return SPRINT_SIGNAL_MAX_AGE_SEC
 
         # если разрешены параллельные сделки — расширяем окно ожидания
         if not self._allow_parallel_trades:

--- a/strategies/constants.py
+++ b/strategies/constants.py
@@ -5,7 +5,7 @@ CLASSIC_ALLOWED_TFS = {"M5", "M15", "M30", "H1", "H4"}
 CLASSIC_SIGNAL_MAX_AGE_SEC = 170.0  # 2 минуты 50 секунд (next_timestamp - 3m + 10s запас)
 CLASSIC_TRADE_BUFFER_SEC = 10.0     # 10 секунд на размещение ставки
 CLASSIC_MIN_TIME_BEFORE_NEXT_SEC = 180.0  # 3 минуты до следующей свечи
-SPRINT_SIGNAL_MAX_AGE_SEC = 5.0
+SPRINT_SIGNAL_MAX_AGE_SEC = 10.0
 MOSCOW_TZ = "Europe/Moscow"
 
 # Параметры по умолчанию для всех стратегий


### PR DESCRIPTION
## Summary
- raise the sprint signal maximum age constant to 10 seconds
- update sprint validation to use the new limit and reference the shared constant

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c349d093c832e85a62ed45516acf3)