### PR TITLE
Handle aiohttp socket timeouts

### DIFF
--- a/core/http_async.py
+++ b/core/http_async.py
@@ -132,9 +132,8 @@ class HttpClient:
                     return {}  # пустой JSON
                 return await parse(resp)
             except (
-                aiohttp.ClientConnectionError,
-                aiohttp.ServerTimeoutError,
-                aiohttp.ClientResponseError,
+                asyncio.TimeoutError,
+                aiohttp.ClientError,
             ) as e:
                 last_exc = e
                 attempt += 1


### PR DESCRIPTION
## Summary
- broaden retryable exceptions to include asyncio timeouts and all aiohttp client errors
- reduce betting failures caused by socket read timeouts being treated as fatal

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3a9914b8832eade2c553c59e55f6)