### PR TITLE
Enable auto expiry defaults in bot settings

### DIFF
--- a/gui/settings_antimartin.py
+++ b/gui/settings_antimartin.py
@@ -28,7 +28,7 @@ class AntimartinSettingsDialog(QDialog):
         self.minutes.setValue(default_minutes)
 
         self.auto_minutes = QCheckBox("Авто")
-        self.auto_minutes.setChecked(bool(self.params.get("auto_minutes", False)))
+        self.auto_minutes.setChecked(bool(self.params.get("auto_minutes", True)))
         self.auto_minutes.toggled.connect(
             lambda checked: self.minutes.setEnabled(not checked)
         )

--- a/gui/settings_fibonacci.py
+++ b/gui/settings_fibonacci.py
@@ -27,7 +27,7 @@ class FibonacciSettingsDialog(QDialog):
         self.minutes.setValue(default_minutes)
 
         self.auto_minutes = QCheckBox("Авто")
-        self.auto_minutes.setChecked(bool(self.params.get("auto_minutes", False)))
+        self.auto_minutes.setChecked(bool(self.params.get("auto_minutes", True)))
         self.auto_minutes.toggled.connect(
             lambda checked: self.minutes.setEnabled(not checked)
         )

--- a/gui/settings_fixed.py
+++ b/gui/settings_fixed.py
@@ -27,7 +27,7 @@ class FixedSettingsDialog(QDialog):
         self.minutes.setValue(default_minutes)
 
         self.auto_minutes = QCheckBox("Авто")
-        self.auto_minutes.setChecked(bool(self.params.get("auto_minutes", False)))
+        self.auto_minutes.setChecked(bool(self.params.get("auto_minutes", True)))
         self.auto_minutes.toggled.connect(
             lambda checked: self.minutes.setEnabled(not checked)
         )

--- a/gui/settings_martingale.py
+++ b/gui/settings_martingale.py
@@ -31,7 +31,7 @@ class MartingaleSettingsDialog(QDialog):
         self.minutes.setValue(default_minutes)
 
         self.auto_minutes = QCheckBox("Авто")
-        self.auto_minutes.setChecked(bool(self.params.get("auto_minutes", False)))
+        self.auto_minutes.setChecked(bool(self.params.get("auto_minutes", True)))
         self.auto_minutes.toggled.connect(
             lambda checked: self.minutes.setEnabled(not checked)
         )

--- a/gui/settings_oscar_grind.py
+++ b/gui/settings_oscar_grind.py
@@ -31,7 +31,7 @@ class OscarGrindSettingsDialog(QDialog):
         self.minutes.setValue(default_minutes)
 
         self.auto_minutes = QCheckBox("Авто")
-        self.auto_minutes.setChecked(bool(self.params.get("auto_minutes", False)))
+        self.auto_minutes.setChecked(bool(self.params.get("auto_minutes", True)))
         self.auto_minutes.toggled.connect(
             lambda checked: self.minutes.setEnabled(not checked)
         )

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -190,7 +190,7 @@ class StrategyControlDialog(QWidget):
         self.strategy_key = strategy_key
         self.minutes = None
         self.auto_minutes = QCheckBox("Авто")
-        self.auto_minutes.setChecked(bool(getv("auto_minutes", False)))
+        self.auto_minutes.setChecked(bool(getv("auto_minutes", True)))
 
         def minutes_row() -> QWidget:
             row = QWidget()


### PR DESCRIPTION
## Summary
- default the auto expiration checkbox to on across bot strategy settings and control dialog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3fe33ea8832eae9d3516784cf66a)