### PR TITLE
Throttle trade queue and slow balance polling

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -355,7 +355,7 @@ class MainWindow(QWidget):
             except Exception as e:
                 self.append_to_log(f"[!] Ошибка при получении баланса: {e}")
                 self.balance_label.setText("Баланс: ошибка")
-            await asyncio.sleep(5)
+            await asyncio.sleep(10)
 
     # -------------------- logging --------------------
 


### PR DESCRIPTION
## Summary
- add optional delay between queued trade executions to reduce API timeouts
- slow balance polling loop to 10 seconds to lessen frequent requests

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c58bd1044832e93618ce0212c4e34)