### PR TITLE
Adjust websocket reconnect logging

### DIFF
--- a/core/ws_client.py
+++ b/core/ws_client.py
@@ -156,7 +156,8 @@ async def listen_to_signals() -> None:
             _log(f"[WS] Соединение закрыто сервером: code={e.code}, reason={e.reason}")
             await asyncio.sleep(3)
         except Exception as e:
-            _log(f"[WS] Ошибка соединения: {type(e).__name__} — {e}")
+            if not isinstance(e, (TimeoutError, asyncio.TimeoutError)):
+                _log(f"[WS] Ошибка соединения: {type(e).__name__} — {e}")
             if not waiting_logged:
                 _log("Ожидание подключения к WebSocket-серверу...")
                 waiting_logged = True


### PR DESCRIPTION
## Summary
- suppress repeated timeout connection error logs
- ensure the websocket waiting status is only logged once while reconnecting

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d00cccdc8832e82bd8faba629bf02)