### PR TITLE
Improve bot lifecycle handling and HTTP error propagation

### DIFF
--- a/core/bot_manager.py
+++ b/core/bot_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Iterable, List, Optional, Type
 
 from core.bot import Bot
@@ -29,8 +30,13 @@ class BotManager:
 
     def stop_all(self) -> None:
         """Остановить всех ботов."""
+        loop = asyncio.get_running_loop()
+        tasks = []
         for bot in list(self.bots):
-            bot.stop()
+            tasks.append(loop.create_task(bot.stop_and_wait()))
+        self.bots.clear()
+        if tasks:
+            loop.create_task(asyncio.gather(*tasks, return_exceptions=True))
 
     def find_by_symbol_and_strategy(
         self, symbol: str, strategy_cls: Type

--- a/core/http_async.py
+++ b/core/http_async.py
@@ -125,13 +125,13 @@ class HttpClient:
         while attempt < self._cfg.max_retries:
             try:
                 resp = await func()
-                if resp.status >= 500:
+                if resp.status >= 400:
                     text = await resp.text()
                     raise aiohttp.ClientResponseError(
                         request_info=resp.request_info,
                         history=resp.history,
                         status=resp.status,
-                        message=f"Server error body: {text[:500]}",
+                        message=f"HTTP {resp.status} body: {text[:500]}",
                         headers=resp.headers,
                     )
                 if resp.status == 204:


### PR DESCRIPTION
## Summary
- log strategy lifecycle errors through callbacks and logger instead of silently swallowing them
- add stop-and-wait support in bot manager to clear references when stopping all bots
- treat all 4xx+ HTTP responses as errors to trigger retries/logging

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d0b56af2c832ebf22628bc5040adb)