### PR TITLE
Resize time GIF display

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -16,7 +16,7 @@ from PyQt6.QtWidgets import (
     QFontDialog,
 )
 from PyQt6.QtGui import QTextCursor, QColor, QFont, QMovie
-from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtCore import Qt, QTimer, QSize
 from pathlib import Path
 from datetime import datetime
 from zoneinfo import ZoneInfo
@@ -168,6 +168,7 @@ class MainWindow(QWidget):
 
         self.time_gif_label = QLabel()
         self.time_gif_label.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+        self.time_gif_label.setFixedSize(120, 120)
         self.time_gif_label.setStyleSheet("padding-top: 8px;")
         self.time_gif_movie: QMovie | None = None
 
@@ -407,6 +408,7 @@ class MainWindow(QWidget):
             self.time_gif_label.setText("Не удалось загрузить гифку")
             return
 
+        movie.setScaledSize(QSize(120, 120))
         self.time_gif_movie = movie
         self.time_gif_label.setMovie(movie)
         movie.start()


### PR DESCRIPTION
## Summary
- limit the time GIF label to a fixed 120x120 area to keep the header compact
- scale the loaded GIF to match the fixed dimensions for consistent display

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e11039f10832e9ae0cefce4df98e7)