### PR TITLE
Reorder time widget layout

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -198,8 +198,8 @@ class MainWindow(QWidget):
         time_box = QWidget()
         time_layout = QVBoxLayout(time_box)
         time_layout.setContentsMargins(0, 0, 0, 0)
-        time_layout.addWidget(self.moscow_time_label, alignment=Qt.AlignmentFlag.AlignHCenter)
         time_layout.addWidget(self.time_gif_label, alignment=Qt.AlignmentFlag.AlignHCenter)
+        time_layout.addWidget(self.moscow_time_label, alignment=Qt.AlignmentFlag.AlignHCenter)
 
         right_box = QWidget()
         right_v = QVBoxLayout(right_box)


### PR DESCRIPTION
## Summary
- move the animated GIF above the Moscow time label in the main window layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e1426830c832e9223f5b9fad35988)