### PR TITLE
Center clock block across top layout

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -211,14 +211,16 @@ class MainWindow(QWidget):
 
         top_layout = QGridLayout()
         top_layout.addWidget(info_box, 0, 0, alignment=Qt.AlignmentFlag.AlignTop)
+        top_layout.addWidget(right_box, 0, 2, alignment=Qt.AlignmentFlag.AlignTop)
         top_layout.addWidget(
             time_box,
+            1,
             0,
             1,
+            3,
             alignment=Qt.AlignmentFlag.AlignHCenter
             | Qt.AlignmentFlag.AlignVCenter,
         )
-        top_layout.addWidget(right_box, 0, 2, alignment=Qt.AlignmentFlag.AlignTop)
         top_layout.setColumnStretch(0, 1)
         top_layout.setColumnStretch(1, 1)
         top_layout.setColumnStretch(2, 1)


### PR DESCRIPTION
## Summary
- span the clock container across the top grid so it centers across the full window width

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e16373668832ea07a89dfc11c7c05)