### PR TITLE
Align time GIF to top

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -219,7 +219,7 @@ class MainWindow(QWidget):
             1,
             3,
             alignment=Qt.AlignmentFlag.AlignHCenter
-            | Qt.AlignmentFlag.AlignVCenter,
+            | Qt.AlignmentFlag.AlignTop,
         )
         top_layout.setColumnStretch(0, 1)
         top_layout.setColumnStretch(1, 1)


### PR DESCRIPTION
## Summary
- adjust main window grid alignment so the time GIF sticks to the top of the layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e182c5064832e821712bdb3dfbc57)