### PR TITLE
Move clock section to top layout

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -211,16 +211,13 @@ class MainWindow(QWidget):
 
         top_layout = QGridLayout()
         top_layout.addWidget(info_box, 0, 0, alignment=Qt.AlignmentFlag.AlignTop)
-        top_layout.addWidget(right_box, 0, 2, alignment=Qt.AlignmentFlag.AlignTop)
         top_layout.addWidget(
             time_box,
-            1,
             0,
             1,
-            3,
-            alignment=Qt.AlignmentFlag.AlignHCenter
-            | Qt.AlignmentFlag.AlignTop,
+            alignment=Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignTop,
         )
+        top_layout.addWidget(right_box, 0, 2, alignment=Qt.AlignmentFlag.AlignTop)
         top_layout.setColumnStretch(0, 1)
         top_layout.setColumnStretch(1, 1)
         top_layout.setColumnStretch(2, 1)


### PR DESCRIPTION
## Summary
- position the time widget in the top header between account info and the app title/version

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e1f51b4a0832ebb2e524383e10cbb)