### PR TITLE
Fix timeframe helper import in GUI dialogs

### DIFF
--- a/gui/settings_fibonacci.py
+++ b/gui/settings_fibonacci.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import (
     QLabel,
     QWidget,
 )
-from strategies.martingale import _minutes_from_timeframe
+from strategies.timeframe_utils import minutes_from_timeframe
 from core.policy import normalize_sprint
 
 
@@ -20,7 +20,7 @@ class FibonacciSettingsDialog(QDialog):
 
         tf = str(self.params.get("timeframe", "M1"))
         symbol = str(self.params.get("symbol", ""))
-        default_minutes = int(self.params.get("minutes", _minutes_from_timeframe(tf)))
+        default_minutes = int(self.params.get("minutes", minutes_from_timeframe(tf)))
 
         self.minutes = QSpinBox()
         self.minutes.setRange(5 if symbol == "BTCUSDT" else 1, 500)
@@ -98,7 +98,7 @@ class FibonacciSettingsDialog(QDialog):
     def get_params(self) -> dict:
         symbol = str(self.params.get("symbol", ""))
         auto_minutes = bool(self.auto_minutes.isChecked())
-        raw_minutes = _minutes_from_timeframe(tf) if auto_minutes else int(self.minutes.value())
+        raw_minutes = minutes_from_timeframe(tf) if auto_minutes else int(self.minutes.value())
         norm = normalize_sprint(symbol, raw_minutes)
         if norm is None:
             norm = 5 if symbol == "BTCUSDT" else (1 if raw_minutes < 3 else max(3, min(500, raw_minutes)))

--- a/gui/settings_fixed.py
+++ b/gui/settings_fixed.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import (
     QLabel,
     QWidget,
 )
-from strategies.martingale import _minutes_from_timeframe
+from strategies.timeframe_utils import minutes_from_timeframe
 from core.policy import normalize_sprint
 
 
@@ -20,7 +20,7 @@ class FixedSettingsDialog(QDialog):
 
         tf = str(self.params.get("timeframe", "M1"))
         symbol = str(self.params.get("symbol", ""))
-        default_minutes = int(self.params.get("minutes", _minutes_from_timeframe(tf)))
+        default_minutes = int(self.params.get("minutes", minutes_from_timeframe(tf)))
 
         self.minutes = QSpinBox()
         self.minutes.setRange(5 if symbol == "BTCUSDT" else 1, 500)
@@ -83,7 +83,7 @@ class FixedSettingsDialog(QDialog):
     def get_params(self) -> dict:
         symbol = str(self.params.get("symbol", ""))
         auto_minutes = bool(self.auto_minutes.isChecked())
-        raw_minutes = _minutes_from_timeframe(tf) if auto_minutes else int(self.minutes.value())
+        raw_minutes = minutes_from_timeframe(tf) if auto_minutes else int(self.minutes.value())
         norm = normalize_sprint(symbol, raw_minutes)
         if norm is None:
             norm = 5 if symbol == "BTCUSDT" else (1 if raw_minutes < 3 else max(3, min(500, raw_minutes)))

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from PyQt6.QtGui import QColor, QBrush, QTextCursor, QFont
 from PyQt6.QtCore import QTimer, Qt
 from core.money import format_amount
-from strategies.martingale import _minutes_from_timeframe
+from strategies.timeframe_utils import minutes_from_timeframe
 from core.policy import normalize_sprint
 from core.money import format_money
 from core.logger import ts
@@ -171,7 +171,7 @@ class StrategyControlDialog(QWidget):
 
         symbol = str(self.bot.strategy_kwargs.get("symbol", ""))
         tf = str(getv("timeframe", self.bot.strategy_kwargs.get("timeframe", "M1")))
-        default_minutes = int(getv("minutes", _minutes_from_timeframe(tf)))
+        default_minutes = int(getv("minutes", minutes_from_timeframe(tf)))
         self.timeframe = tf
 
         self.trade_type = QComboBox()
@@ -563,7 +563,7 @@ class StrategyControlDialog(QWidget):
         norm = m
         raw_minutes = m
         if auto_minutes and trade_type == "sprint":
-            raw_minutes = _minutes_from_timeframe(self.timeframe)
+            raw_minutes = minutes_from_timeframe(self.timeframe)
             norm = raw_minutes
         if trade_type != "classic" and self.minutes is not None:
             norm = normalize_sprint(symbol, raw_minutes)


### PR DESCRIPTION
## Summary
- replace references to the removed `_minutes_from_timeframe` helper with the shared `minutes_from_timeframe` utility across GUI settings dialogs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e73d2191c832ebc4253a5fba3fa14)