### PR TITLE
Reduce HTTP timeouts to avoid long delays

### DIFF
--- a/core/http_async.py
+++ b/core/http_async.py
@@ -12,12 +12,14 @@ import aiohttp
 
 log = logging.getLogger(__name__)
 
-# More relaxed defaults to tolerate slow endpoints.
+# Более агрессивные таймауты, чтобы не зависать на минуту при глухом сервере.
+# Даже при 5 ретраях суммарное ожидание теперь считается секундами, а не
+# минутами, что уменьшает задержку постановки сделок.
 DEFAULT_TIMEOUT = aiohttp.ClientTimeout(
-    total=60,
-    connect=10,
-    sock_connect=10,
-    sock_read=55,
+    total=25,
+    connect=8,
+    sock_connect=8,
+    sock_read=12,
 )
 
 


### PR DESCRIPTION
## Summary
- tighten default aiohttp timeouts to fail faster when endpoints hang
- document the intent to avoid minute-long stalls before retries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fa789b9a0832e9b2fc3b187bbdc67)