### PR TITLE
Yield event loop between trade queue tasks

### DIFF
--- a/core/trade_queue.py
+++ b/core/trade_queue.py
@@ -83,6 +83,9 @@ class TradeQueue:
                 future.set_result(result)
 
             self._queue.task_done()
+            # Отдаём управление циклу, чтобы не забивать его при большом количестве
+            # быстрых операций.
+            await asyncio.sleep(0)
 
 
 trade_queue = TradeQueue()


### PR DESCRIPTION
## Summary
- add an explicit event-loop yield between trade queue tasks so background processing remains cooperative even under rapid queues

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fb11a2c5c832e97fe907dafb4c084)