### PR TITLE
Use fixed 0.5s polling for trade result checks

### DIFF
--- a/core/intrade_api.py
+++ b/core/intrade_api.py
@@ -280,7 +280,7 @@ async def check_trade_result(session, user_id, user_hash, trade_id, wait_time=60
 
     После ожидания ``wait_time`` секунд отправляется запрос на получение
     результата сделки. Если ответ не содержит нужных данных, выполняется
-    повторная проверка каждую секунду до появления результата. Отмена
+    повторная проверка каждые 0.5 секунды до появления результата. Отмена
     корутины приводит к немедленному выходу из функции.
     """
 
@@ -299,4 +299,4 @@ async def check_trade_result(session, user_id, user_hash, trade_id, wait_time=60
         except Exception:
             pass
 
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.5)

--- a/core/intrade_api_async.py
+++ b/core/intrade_api_async.py
@@ -198,16 +198,14 @@ async def check_trade_result(
     wait_time: float = 60.0,
     *,
     max_attempts: int = 60,
-    initial_poll_delay: float = 1.0,
-    backoff_factor: float = 1.5,
-    max_poll_delay: float = 10.0,
+    poll_interval: float = 0.5,
 ) -> Optional[float]:
     """Fetch trade result, polling until it becomes available.
 
     Первоначально ждём ``wait_time`` секунд (время закрытия спринта),
     затем запрашиваем результат сделки. Если результат не получен, то
-    продолжаем проверять его с растущей задержкой, пока не достигнем
-    ``max_attempts``. Короутина прерывается исключением
+    продолжаем проверять его каждые ``poll_interval`` секунд, пока не
+    достигнем ``max_attempts``. Короутина прерывается исключением
     ``asyncio.CancelledError`` или возвращает ``None``, если ответ так и
     не получен.
 
@@ -217,7 +215,7 @@ async def check_trade_result(
     payload = {"user_id": user_id, "user_hash": user_hash, "trade_id": trade_id}
 
     attempts = 0
-    poll_delay = max(0.0, initial_poll_delay)
+    poll_interval = max(0.0, poll_interval)
 
     while attempts < max_attempts:
         try:
@@ -237,8 +235,7 @@ async def check_trade_result(
 
         attempts += 1
         # результат ещё не готов — подождём и попробуем снова
-        await asyncio.sleep(poll_delay)
-        poll_delay = min(max_poll_delay, poll_delay * backoff_factor)
+        await asyncio.sleep(poll_interval)
 
     return None
 


### PR DESCRIPTION
## Summary
- use a fixed 0.5s interval for asynchronous trade result polling instead of increasing backoff
- align synchronous trade result polling and docs with the 0.5s interval

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fb5c1313c832ebc9d18d8f3047676)