### PR TITLE
Disable queuing pending trading signals by default

### DIFF
--- a/strategies/constants.py
+++ b/strategies/constants.py
@@ -20,6 +20,7 @@ DEFAULTS = {
     "grace_delay_sec": 30.0,
     "trade_type": "classic",
     "allow_parallel_trades": True,
+    "queue_pending_signals": False,
     "classic_signal_max_age_sec": 170.0,
     "classic_trade_buffer_sec": 10.0,
     "classic_min_time_before_next_sec": 180.0,

--- a/strategies/log_messages.py
+++ b/strategies/log_messages.py
@@ -204,6 +204,10 @@ def signal_deferred(symbol: str) -> str:
     return f"[{symbol}] Сигнал отложен (активная сделка)"
 
 
+def signal_ignored(symbol: str) -> str:
+    return f"[{symbol}] ⚠ Сигнал проигнорирован (активная сделка)"
+
+
 def deferred_signal_outdated(symbol: str, reason: str) -> str:
     return f"[{symbol}] ⏰ Отложенный сигнал устарел: {reason} -> пропуск"
 

--- a/strategies/strategy_common.py
+++ b/strategies/strategy_common.py
@@ -29,6 +29,7 @@ from strategies.log_messages import (
     queue_processor_started,
     queue_signal_outdated,
     removed_stale_signals,
+    signal_ignored,
     signal_deferred,
     signal_enqueued,
     signal_listener_started,
@@ -45,6 +46,10 @@ class StrategyCommon:
     def __init__(self, strategy_instance):
         self.strategy = strategy_instance
         self.log = strategy_instance.log or (lambda s: None)
+
+        self._queue_pending_signals = bool(
+            strategy_instance.params.get("queue_pending_signals", False)
+        )
 
         self._signal_queues: Dict[str, asyncio.Queue] = {}
         self._signal_processors: Dict[str, asyncio.Task] = {}
@@ -313,6 +318,10 @@ class StrategyCommon:
     async def _handle_pending_signal(self, trade_key: str, signal_data: dict):
         symbol, _ = trade_key.split("_", 1)
         log = self.log
+
+        if not self._queue_pending_signals:
+            log(signal_ignored(symbol))
+            return
 
         if trade_key not in self._pending_signals:
             self._pending_signals[trade_key] = asyncio.Queue(maxsize=1)  # только 1 слот


### PR DESCRIPTION
## Summary
- add a `queue_pending_signals` flag defaulting to false to stop deferring extra signals
- log and ignore deferred signals when queuing is disabled to avoid extra stake attempts
- add a dedicated log message for ignored signals

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fd3e20398832eb0b970d1aad3113d)