### PR TITLE
Add signal handling mode selector

### DIFF
--- a/gui/settings_antimartin.py
+++ b/gui/settings_antimartin.py
@@ -4,6 +4,7 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QDialogButtonBox,
     QCheckBox,
+    QComboBox,
     QHBoxLayout,
     QLabel,
     QWidget,
@@ -53,21 +54,14 @@ class AntimartinSettingsDialog(QDialog):
         self.min_percent.setRange(0, 100)
         self.min_percent.setValue(self.params.get("min_percent", 70))
 
-        self.parallel_trades = QCheckBox()
-        self.parallel_trades.setChecked(
-            bool(self.params.get("allow_parallel_trades", True))
+        allow_parallel = bool(self.params.get("allow_parallel_trades", True))
+        use_common = bool(self.params.get("use_common_series", True))
+        single_series = use_common or not allow_parallel
+        self.series_mode = QComboBox()
+        self.series_mode.addItems(
+            ["Вести единую серию", "Обрабатывать множество сигналов"]
         )
-        parallel_label = QLabel("Обрабатывать множество сигналов")
-        parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
-
-        self.common_series = QCheckBox()
-        self.common_series.setChecked(
-            bool(self.params.get("use_common_series", True))
-        )
-        common_series_label = QLabel("Общая серия для всех сигналов")
-        common_series_label.mousePressEvent = (
-            lambda event: self.common_series.toggle()
-        )
+        self.series_mode.setCurrentIndex(0 if single_series else 1)
 
         minutes_row = QWidget()
         minutes_layout = QHBoxLayout(minutes_row)
@@ -84,8 +78,7 @@ class AntimartinSettingsDialog(QDialog):
         form.addRow("Повторов серии", self.repeat_count)
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
-        form.addRow(parallel_label, self.parallel_trades)
-        form.addRow(common_series_label, self.common_series)
+        form.addRow("Режим сигналов", self.series_mode)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -112,6 +105,6 @@ class AntimartinSettingsDialog(QDialog):
             "repeat_count": self.repeat_count.value(),
             "min_balance": self.min_balance.value(),
             "min_percent": self.min_percent.value(),
-            "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
-            "use_common_series": bool(self.common_series.isChecked()),
+            "allow_parallel_trades": self.series_mode.currentIndex() == 1,
+            "use_common_series": self.series_mode.currentIndex() == 0,
         }

--- a/gui/settings_fibonacci.py
+++ b/gui/settings_fibonacci.py
@@ -4,6 +4,7 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QDialogButtonBox,
     QCheckBox,
+    QComboBox,
     QHBoxLayout,
     QLabel,
     QWidget,
@@ -52,21 +53,14 @@ class FibonacciSettingsDialog(QDialog):
         self.min_percent.setRange(0, 100)
         self.min_percent.setValue(self.params.get("min_percent", 70))
 
-        self.parallel_trades = QCheckBox()
-        self.parallel_trades.setChecked(
-            bool(self.params.get("allow_parallel_trades", True))
+        allow_parallel = bool(self.params.get("allow_parallel_trades", True))
+        use_common = bool(self.params.get("use_common_series", True))
+        single_series = use_common or not allow_parallel
+        self.series_mode = QComboBox()
+        self.series_mode.addItems(
+            ["Вести единую серию", "Обрабатывать множество сигналов"]
         )
-        parallel_label = QLabel("Обрабатывать множество сигналов")
-        parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
-
-        self.common_series = QCheckBox()
-        self.common_series.setChecked(
-            bool(self.params.get("use_common_series", True))
-        )
-        common_series_label = QLabel("Общая серия для всех сигналов")
-        common_series_label.mousePressEvent = (
-            lambda event: self.common_series.toggle()
-        )
+        self.series_mode.setCurrentIndex(0 if single_series else 1)
 
         minutes_row = QWidget()
         minutes_layout = QHBoxLayout(minutes_row)
@@ -83,8 +77,7 @@ class FibonacciSettingsDialog(QDialog):
         form.addRow("Повторов серии", self.repeat_count)
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
-        form.addRow(parallel_label, self.parallel_trades)
-        form.addRow(common_series_label, self.common_series)
+        form.addRow("Режим сигналов", self.series_mode)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -110,6 +103,6 @@ class FibonacciSettingsDialog(QDialog):
             "repeat_count": self.repeat_count.value(),
             "min_balance": self.min_balance.value(),
             "min_percent": self.min_percent.value(),
-            "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
-            "use_common_series": bool(self.common_series.isChecked()),
+            "allow_parallel_trades": self.series_mode.currentIndex() == 1,
+            "use_common_series": self.series_mode.currentIndex() == 0,
         }

--- a/gui/settings_martingale.py
+++ b/gui/settings_martingale.py
@@ -5,6 +5,7 @@ from PyQt6.QtWidgets import (
     QDoubleSpinBox,
     QDialogButtonBox,
     QCheckBox,
+    QComboBox,
     QHBoxLayout,
     QLabel,
     QWidget,
@@ -61,21 +62,14 @@ class MartingaleSettingsDialog(QDialog):
         self.min_percent.setRange(0, 100)
         self.min_percent.setValue(self.params.get("min_percent", 70))
 
-        self.parallel_trades = QCheckBox()
-        self.parallel_trades.setChecked(
-            bool(self.params.get("allow_parallel_trades", True))
+        allow_parallel = bool(self.params.get("allow_parallel_trades", True))
+        use_common = bool(self.params.get("use_common_series", True))
+        single_series = use_common or not allow_parallel
+        self.series_mode = QComboBox()
+        self.series_mode.addItems(
+            ["Вести единую серию", "Обрабатывать множество сигналов"]
         )
-        parallel_label = QLabel("Обрабатывать множество сигналов")
-        parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
-
-        self.common_series = QCheckBox()
-        self.common_series.setChecked(
-            bool(self.params.get("use_common_series", True))
-        )
-        common_series_label = QLabel("Общая серия для всех сигналов")
-        common_series_label.mousePressEvent = (
-            lambda event: self.common_series.toggle()
-        )
+        self.series_mode.setCurrentIndex(0 if single_series else 1)
 
         form = QFormLayout()
         minutes_row = QWidget()
@@ -93,8 +87,7 @@ class MartingaleSettingsDialog(QDialog):
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Коэффициент", self.coefficient)
         form.addRow("Мин. процент", self.min_percent)
-        form.addRow(parallel_label, self.parallel_trades)
-        form.addRow(common_series_label, self.common_series)
+        form.addRow("Режим сигналов", self.series_mode)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -123,6 +116,6 @@ class MartingaleSettingsDialog(QDialog):
             "min_balance": self.min_balance.value(),
             "coefficient": self.coefficient.value(),
             "min_percent": self.min_percent.value(),
-            "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
-            "use_common_series": bool(self.common_series.isChecked()),
+            "allow_parallel_trades": self.series_mode.currentIndex() == 1,
+            "use_common_series": self.series_mode.currentIndex() == 0,
         }

--- a/gui/settings_oscar_grind.py
+++ b/gui/settings_oscar_grind.py
@@ -5,6 +5,7 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QDialogButtonBox,
     QCheckBox,
+    QComboBox,
     QHBoxLayout,
     QLabel,
     QWidget,
@@ -66,21 +67,14 @@ class OscarGrindSettingsDialog(QDialog):
         double_entry_label = QLabel("Двойной вход на свечу")
         double_entry_label.mousePressEvent = lambda event: self.double_entry.toggle()
 
-        self.parallel_trades = QCheckBox()
-        self.parallel_trades.setChecked(
-            bool(self.params.get("allow_parallel_trades", True))
+        allow_parallel = bool(self.params.get("allow_parallel_trades", True))
+        use_common = bool(self.params.get("use_common_series", True))
+        single_series = use_common or not allow_parallel
+        self.series_mode = QComboBox()
+        self.series_mode.addItems(
+            ["Вести единую серию", "Обрабатывать множество сигналов"]
         )
-        parallel_label = QLabel("Обрабатывать множество сигналов")
-        parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
-
-        self.common_series = QCheckBox()
-        self.common_series.setChecked(
-            bool(self.params.get("use_common_series", True))
-        )
-        common_series_label = QLabel("Общая серия для всех сигналов")
-        common_series_label.mousePressEvent = (
-            lambda event: self.common_series.toggle()
-        )
+        self.series_mode.setCurrentIndex(0 if single_series else 1)
 
         minutes_row = QWidget()
         minutes_layout = QHBoxLayout(minutes_row)
@@ -98,8 +92,7 @@ class OscarGrindSettingsDialog(QDialog):
         form.addRow("Мин. баланс", self.min_balance)
         form.addRow("Мин. процент", self.min_percent)
         form.addRow(double_entry_label, self.double_entry)
-        form.addRow(parallel_label, self.parallel_trades)
-        form.addRow(common_series_label, self.common_series)
+        form.addRow("Режим сигналов", self.series_mode)
 
         btns = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
@@ -128,6 +121,6 @@ class OscarGrindSettingsDialog(QDialog):
             "min_balance": int(self.min_balance.value()),
             "min_percent": int(self.min_percent.value()),
             "double_entry": bool(self.double_entry.isChecked()),
-            "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
-            "use_common_series": bool(self.common_series.isChecked()),
+            "allow_parallel_trades": self.series_mode.currentIndex() == 1,
+            "use_common_series": self.series_mode.currentIndex() == 0,
         }

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -217,13 +217,16 @@ class StrategyControlDialog(QWidget):
         th.addWidget(self.btn_apply_template)
         box_v.addWidget(template_row)
 
-        self.parallel_trades = QCheckBox()
-        self.parallel_trades.setChecked(bool(getv("allow_parallel_trades", True)))
-        self.common_series = QCheckBox()
-        self.common_series.setChecked(bool(getv("use_common_series", True)))
-        if strategy_key == "fixed":
-            self.common_series.setChecked(False)
-            self.common_series.setEnabled(False)
+        allow_parallel = bool(getv("allow_parallel_trades", True))
+        use_common = (
+            False if strategy_key == "fixed" else bool(getv("use_common_series", True))
+        )
+        single_series = use_common or not allow_parallel
+        self.series_mode = QComboBox()
+        self.series_mode.addItems(
+            ["Вести единую серию", "Обрабатывать множество сигналов"]
+        )
+        self.series_mode.setCurrentIndex(0 if single_series else 1)
 
         if strategy_key in ("oscar_grind_1", "oscar_grind_2"):
             self.minutes = QSpinBox()
@@ -334,14 +337,7 @@ class StrategyControlDialog(QWidget):
                 form.addRow("Коэффициент", self.coefficient)
             form.addRow("Мин. процент", self.min_percent)
 
-        parallel_label = QLabel("Обрабатывать множество сигналов")
-        parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
-
-        form.addRow(parallel_label, self.parallel_trades)
-        if strategy_key != "fixed":
-            common_series_label = QLabel("Общая серия для всех сигналов")
-            common_series_label.mousePressEvent = lambda event: self.common_series.toggle()
-            form.addRow(common_series_label, self.common_series)
+        form.addRow("Режим сигналов", self.series_mode)
 
         def _update_minutes_enabled(text: str):
             if self.minutes is not None:
@@ -618,10 +614,9 @@ class StrategyControlDialog(QWidget):
             if trade_type != "classic" and self.minutes is not None:
                 new_params["minutes"] = int(norm)
         new_params["trade_type"] = trade_type
-        new_params["allow_parallel_trades"] = self.parallel_trades.isChecked()
-        new_params["use_common_series"] = (
-            False if strategy_key == "fixed" else self.common_series.isChecked()
-        )
+        single_series = self.series_mode.currentIndex() == 0
+        new_params["allow_parallel_trades"] = not single_series
+        new_params["use_common_series"] = False if strategy_key == "fixed" else single_series
         return new_params
 
     def apply_settings(self):
@@ -701,14 +696,15 @@ class StrategyControlDialog(QWidget):
                 self.min_percent.setValue(int(v))
             elif k == "double_entry" and hasattr(self, "double_entry"):
                 self.double_entry.setChecked(bool(v))
-            elif k == "allow_parallel_trades" and hasattr(self, "parallel_trades"):
-                self.parallel_trades.setChecked(bool(v))
-            elif (
-                k == "use_common_series"
-                and hasattr(self, "common_series")
-                and self.strategy_key != "fixed"
-            ):
-                self.common_series.setChecked(bool(v))
+        if hasattr(self, "series_mode"):
+            allow_parallel = bool(params.get("allow_parallel_trades", True))
+            use_common_series = (
+                False
+                if self.strategy_key == "fixed"
+                else bool(params.get("use_common_series", True))
+            )
+            single_series = use_common_series or not allow_parallel
+            self.series_mode.setCurrentIndex(0 if single_series else 1)
 
     def apply_template(self):
         idx = self.template_combo.currentIndex()


### PR DESCRIPTION
## Summary
- replace separate parallel/common checkboxes with a single signal mode selector across strategy dialogs
- ensure single-series selection enforces serialized handling while parallel mode keeps independent processing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fd69b9468832e8587cbfec4ee8fdd)