### PR TITLE
Set allow_parallel_trades defaults to false

### DIFF
--- a/gui/settings_antimartin.py
+++ b/gui/settings_antimartin.py
@@ -55,7 +55,7 @@ class AntimartinSettingsDialog(QDialog):
 
         self.parallel_trades = QCheckBox()
         self.parallel_trades.setChecked(
-            bool(self.params.get("allow_parallel_trades", True))
+            bool(self.params.get("allow_parallel_trades", False))
         )
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()

--- a/gui/settings_fibonacci.py
+++ b/gui/settings_fibonacci.py
@@ -54,7 +54,7 @@ class FibonacciSettingsDialog(QDialog):
 
         self.parallel_trades = QCheckBox()
         self.parallel_trades.setChecked(
-            bool(self.params.get("allow_parallel_trades", True))
+            bool(self.params.get("allow_parallel_trades", False))
         )
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()

--- a/gui/settings_fixed.py
+++ b/gui/settings_fixed.py
@@ -50,7 +50,7 @@ class FixedSettingsDialog(QDialog):
 
         self.parallel_trades = QCheckBox()
         self.parallel_trades.setChecked(
-            bool(self.params.get("allow_parallel_trades", True))
+            bool(self.params.get("allow_parallel_trades", False))
         )
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()
@@ -97,4 +97,3 @@ class FixedSettingsDialog(QDialog):
             "allow_parallel_trades": bool(self.parallel_trades.isChecked()),
             "use_common_series": False,
         }
-

--- a/gui/settings_martingale.py
+++ b/gui/settings_martingale.py
@@ -63,7 +63,7 @@ class MartingaleSettingsDialog(QDialog):
 
         self.parallel_trades = QCheckBox()
         self.parallel_trades.setChecked(
-            bool(self.params.get("allow_parallel_trades", True))
+            bool(self.params.get("allow_parallel_trades", False))
         )
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()

--- a/gui/settings_oscar_grind.py
+++ b/gui/settings_oscar_grind.py
@@ -68,7 +68,7 @@ class OscarGrindSettingsDialog(QDialog):
 
         self.parallel_trades = QCheckBox()
         self.parallel_trades.setChecked(
-            bool(self.params.get("allow_parallel_trades", True))
+            bool(self.params.get("allow_parallel_trades", False))
         )
         parallel_label = QLabel("Обрабатывать множество сигналов")
         parallel_label.mousePressEvent = lambda event: self.parallel_trades.toggle()

--- a/gui/strategy_control_dialog.py
+++ b/gui/strategy_control_dialog.py
@@ -218,7 +218,7 @@ class StrategyControlDialog(QWidget):
         box_v.addWidget(template_row)
 
         self.parallel_trades = QCheckBox()
-        self.parallel_trades.setChecked(bool(getv("allow_parallel_trades", True)))
+        self.parallel_trades.setChecked(bool(getv("allow_parallel_trades", False)))
         self.common_series = QCheckBox()
         self.common_series.setChecked(bool(getv("use_common_series", True)))
         if strategy_key == "fixed":

--- a/strategies/base_trading_strategy.py
+++ b/strategies/base_trading_strategy.py
@@ -105,7 +105,7 @@ class BaseTradingStrategy(StrategyBase):
         self._series_counters: dict[str, int] = {}
 
         # Параллельная обработка
-        self._allow_parallel_trades = bool(self.params.get("allow_parallel_trades", True))
+        self._allow_parallel_trades = bool(self.params.get("allow_parallel_trades", False))
         self.params["allow_parallel_trades"] = self._allow_parallel_trades
 
         # Активные сделки и задачи

--- a/strategies/fixed.py
+++ b/strategies/fixed.py
@@ -108,7 +108,7 @@ class FixedStakeStrategy(BaseTradingStrategy):
         return lock
 
     def allow_concurrent_trades_per_key(self) -> bool:
-        return bool(self.params.get("allow_parallel_trades", True))
+        return bool(self.params.get("allow_parallel_trades", False))
 
     def is_series_active(self, trade_key: str) -> bool:
         # Для FixedStake серии нет, но если параллель запрещена — блокируем ключ

--- a/strategies/strategy_common.py
+++ b/strategies/strategy_common.py
@@ -195,7 +195,7 @@ class StrategyCommon:
         symbol, timeframe = trade_key.split("_", 1)
         log = self.log
 
-        allow_parallel = self.strategy.params.get("allow_parallel_trades", True)
+        allow_parallel = self.strategy.params.get("allow_parallel_trades", False)
         log(queue_processor_started(symbol, trade_key, allow_parallel))
 
         while self.strategy._running:
@@ -353,7 +353,7 @@ class StrategyCommon:
     async def _process_pending_signals(self, trade_key: str):
         symbol, _ = trade_key.split("_", 1)
         log = self.log
-        allow_parallel = self.strategy.params.get("allow_parallel_trades", True)
+        allow_parallel = self.strategy.params.get("allow_parallel_trades", False)
 
         try:
             if not allow_parallel:
@@ -444,7 +444,7 @@ class StrategyCommon:
             self._reschedule_pending_processing(trade_key)
             return
 
-        if not self.strategy.params.get("allow_parallel_trades", True):
+        if not self.strategy.params.get("allow_parallel_trades", False):
             try:
                 task = asyncio.create_task(self.strategy._process_single_signal(last_signal))
                 await task

--- a/templates/fibonacci.json
+++ b/templates/fibonacci.json
@@ -2,7 +2,7 @@
   {
     "name": "Шаблон 1",
     "params": {
-      "allow_parallel_trades": true
+      "allow_parallel_trades": false
     }
   }
 ]

--- a/templates/martingale.json
+++ b/templates/martingale.json
@@ -9,7 +9,7 @@
       "min_balance": 100,
       "coefficient": 2.0,
       "min_percent": 70,
-      "allow_parallel_trades": true
+      "allow_parallel_trades": false
     }
   },
   {
@@ -22,7 +22,7 @@
       "min_balance": 100,
       "coefficient": 2.0,
       "min_percent": 70,
-      "allow_parallel_trades": true
+      "allow_parallel_trades": false
     }
   },
   {
@@ -35,7 +35,7 @@
       "min_balance": 100,
       "coefficient": 2.0,
       "min_percent": 70,
-      "allow_parallel_trades": true
+      "allow_parallel_trades": false
     }
   },
   {
@@ -48,7 +48,7 @@
       "coefficient": 2.0,
       "min_percent": 70,
       "trade_type": "classic",
-      "allow_parallel_trades": true
+      "allow_parallel_trades": false
     }
   }
 ]

--- a/templates/oscar_grind_2.json
+++ b/templates/oscar_grind_2.json
@@ -9,7 +9,7 @@
       "min_percent": 70,
       "double_entry": true,
       "trade_type": "classic",
-      "allow_parallel_trades": true
+      "allow_parallel_trades": false
     }
   }
 ]


### PR DESCRIPTION
## Summary
- default the allow_parallel_trades option to false across strategy initialization and UI dialogs so the checkbox starts unchecked
- align strategy templates with the new default allow_parallel_trades setting

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940d0ef1d4c832eab2d3624d4fabf0f)