### PR TITLE
Ensure strategies pull queued signals while waiting

### DIFF
--- a/strategies/strategy_helpers.py
+++ b/strategies/strategy_helpers.py
@@ -124,15 +124,11 @@ async def wait_for_new_signal(strategy, trade_key: str, *, timeout: float, poll_
     if common is None:
         return None
 
-    start = asyncio.get_event_loop().time()
-    while strategy._running and (asyncio.get_event_loop().time() - start) < timeout:
-        await strategy._pause_point()
-        new_signal = common.pop_latest_signal(trade_key)
-        if new_signal:
-            return new_signal
-        await asyncio.sleep(poll_interval)
-
-    return None
+    return await common.wait_for_pending_signal(
+        trade_key,
+        timeout=timeout,
+        poll_interval=poll_interval,
+    )
 
 
 async def is_payout_low_now(strategy, symbol: str) -> bool:


### PR DESCRIPTION
## Summary
- add a shared StrategyCommon helper that waits for pending signals and returns the freshest entry
- reuse the new helper in wait_for_new_signal so strategy steps both wait for and consume queued signals

## Testing
- python -m compileall strategies/strategy_common.py strategies/strategy_helpers.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940edc7d8c8832e9ee378ad320e66b5)