### PR TITLE
Add pause checkpoints to strategy loops

### DIFF
--- a/strategies/base.py
+++ b/strategies/base.py
@@ -215,11 +215,16 @@ class StrategyBase:
         queue = self._signal_queue
         fetcher = self._signal_listener_fetcher
         since_version = self._signal_queue_since_version
-       
+
         while self._running and not self._stop_event.is_set():
             if fetcher is None or queue is None:
                 break
-               
+
+            try:
+                await self._pause_point()
+            except asyncio.CancelledError:
+                break
+
             try:
                 payload = await fetcher(since_version)
             except asyncio.CancelledError:

--- a/strategies/base_trading_strategy.py
+++ b/strategies/base_trading_strategy.py
@@ -814,6 +814,7 @@ class BaseTradingStrategy(StrategyBase):
 
         try:
             while self._running:
+                await self._pause_point()
                 await asyncio.sleep(1.0)
         except asyncio.CancelledError:
             pass

--- a/strategies/martingale.py
+++ b/strategies/martingale.py
@@ -202,6 +202,7 @@ class MartingaleStrategy(BaseTradingStrategy):
 
         # Стартовая валидация (если невалидно — ждём новый сигнал, НЕ завершая серию)
         while self._running:
+            await self._pause_point()
             current_time = datetime.now(MOSCOW_ZONE)
 
             if self._trade_type == "classic":

--- a/strategies/oscar_grind_base.py
+++ b/strategies/oscar_grind_base.py
@@ -157,6 +157,7 @@ class OscarGrindStrategy(BaseTradingStrategy):
 
         # Важно: если сигнал неактуален — ждём новый, а не выходим
         while self._running:
+            await self._pause_point()
             now = self.now_moscow()
             if self._trade_type == "classic":
                 ok, reason = self._is_signal_valid_for_classic(signal_data, now, for_placement=True)


### PR DESCRIPTION
## Summary
- add pause waits to the shared signal listener and idle run loop so pausing stops background activity
- ensure martingale and Oscar Grind initial validation loops respect pause/stop events before continuing

## Testing
- python -m compileall strategies

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940efb16114832ea3a1c02fd16717e4)