### PR TITLE
Translate direction labels in logs to Russian

### DIFF
--- a/core/ws_client.py
+++ b/core/ws_client.py
@@ -142,7 +142,7 @@ async def listen_to_signals() -> None:
 
                     # Лог: время без таймзоны
                     dt_naive = sig.timestamp.astimezone(MOSCOW_TZ).replace(tzinfo=None)
-                    msg_dir = {1: "UP", 2: "DOWN", None: "none"}[sig.direction]
+                    msg_dir = {1: "ВВЕРХ", 2: "ВНИЗ", None: "none"}[sig.direction]
                     tail = ""
                     if sig.next_timestamp:
                         n1 = sig.next_timestamp.astimezone(MOSCOW_TZ).strftime("%H:%M")

--- a/strategies/log_messages.py
+++ b/strategies/log_messages.py
@@ -74,7 +74,7 @@ def trade_summary(
     direction: int,
     payout: int,
 ) -> str:
-    side = "UP" if direction == 1 else "DOWN"
+    side = "ВВЕРХ" if direction == 1 else "ВНИЗ"
     return f"[{symbol}] stake={stake} min={minutes} side={side} payout={payout}%"
 
 
@@ -239,7 +239,7 @@ def series_completed(symbol: str, timeframe: str, strategy_name: str) -> str:
 
 
 def trade_step(symbol: str, step: int, stake: str, minutes: int, direction: int, payout: int) -> str:
-    side = "UP" if direction == 1 else "DOWN"
+    side = "ВВЕРХ" if direction == 1 else "ВНИЗ"
     return (
         f"[{symbol}] step={step} stake={stake} min={minutes} "
         f"side={side} payout={payout}%"
@@ -397,4 +397,3 @@ def oscar_loss(symbol: str, profit: str, next_stake: str) -> str:
         f"[{symbol}] ❌ LOSS: profit={profit}. "
         f"Следующая ставка остаётся {next_stake}."
     )
-


### PR DESCRIPTION
## Summary
- update WebSocket signal log messages to show direction in Russian
- adjust trade summary and step log helpers to use Russian direction labels

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940f76d1c38832ea037b2dea6a8e82d)