### PR TITLE
Remove delays between trade result checks

### DIFF
--- a/core/intrade_api.py
+++ b/core/intrade_api.py
@@ -280,8 +280,9 @@ async def check_trade_result(session, user_id, user_hash, trade_id, wait_time=60
 
     После ожидания ``wait_time`` секунд отправляется запрос на получение
     результата сделки. Если ответ не содержит нужных данных, выполняется
-    повторная проверка каждую секунду до появления результата. Отмена
-    корутины приводит к немедленному выходу из функции.
+    повторная проверка без дополнительной задержки до появления
+    результата. Отмена корутины приводит к немедленному выходу из
+    функции.
     """
 
     await asyncio.sleep(wait_time)
@@ -299,4 +300,4 @@ async def check_trade_result(session, user_id, user_hash, trade_id, wait_time=60
         except Exception:
             pass
 
-        await asyncio.sleep(1)
+        await asyncio.sleep(0)

--- a/core/intrade_api_async.py
+++ b/core/intrade_api_async.py
@@ -198,18 +198,15 @@ async def check_trade_result(
     wait_time: float = 60.0,
     *,
     max_attempts: int = 60,
-    initial_poll_delay: float = 1.0,
-    backoff_factor: float = 1.5,
-    max_poll_delay: float = 10.0,
 ) -> Optional[float]:
     """Fetch trade result, polling until it becomes available.
 
     Первоначально ждём ``wait_time`` секунд (время закрытия спринта),
-    затем запрашиваем результат сделки. Если результат не получен, то
-    продолжаем проверять его с растущей задержкой, пока не достигнем
-    ``max_attempts``. Короутина прерывается исключением
-    ``asyncio.CancelledError`` или возвращает ``None``, если ответ так и
-    не получен.
+    затем запрашиваем результат сделки. Если результат не получен,
+    продолжаем проверять его без дополнительной задержки, пока не
+    достигнем ``max_attempts``. Короутина прерывается исключением
+    ``asyncio.CancelledError`` или возвращает ``None``, если ответ так
+    и не получен.
 
     Возвращает прибыль (``result - investment``) как ``float``.
     """
@@ -217,7 +214,6 @@ async def check_trade_result(
     payload = {"user_id": user_id, "user_hash": user_hash, "trade_id": trade_id}
 
     attempts = 0
-    poll_delay = max(0.0, initial_poll_delay)
 
     while attempts < max_attempts:
         try:
@@ -236,9 +232,8 @@ async def check_trade_result(
                 pass
 
         attempts += 1
-        # результат ещё не готов — подождём и попробуем снова
-        await asyncio.sleep(poll_delay)
-        poll_delay = min(max_poll_delay, poll_delay * backoff_factor)
+        # результат ещё не готов — пробуем снова без дополнительной задержки
+        await asyncio.sleep(0)
 
     return None
 

--- a/core/trade_result_queue.py
+++ b/core/trade_result_queue.py
@@ -74,9 +74,6 @@ class TradeResultQueue:
         trade_id: str,
         wait_time: float = 60.0,
         max_attempts: int = 60,
-        initial_poll_delay: float = 1.0,
-        backoff_factor: float = 1.5,
-        max_poll_delay: float = 10.0,
     ) -> Optional[float]:
         """Поставить запрос проверки сделки в очередь."""
 
@@ -88,9 +85,6 @@ class TradeResultQueue:
                 trade_id=trade_id,
                 wait_time=wait_time,
                 max_attempts=max_attempts,
-                initial_poll_delay=initial_poll_delay,
-                backoff_factor=backoff_factor,
-                max_poll_delay=max_poll_delay,
             )
         )
 


### PR DESCRIPTION
## Summary
- remove additional polling delays when checking trade results in both async and sync APIs
- simplify trade result queue parameters now that polling is immediate

## Testing
- python -m compileall core strategies

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694101bb6604832e9dffa35d35077cd6)