### PR TITLE
Use constant trade result polling interval

### DIFF
--- a/core/intrade_api_async.py
+++ b/core/intrade_api_async.py
@@ -199,14 +199,13 @@ async def check_trade_result(
     *,
     max_attempts: int = 60,
     initial_poll_delay: float = 1.0,
-    backoff_factor: float = 1.5,
     max_poll_delay: float = 10.0,
 ) -> Optional[float]:
     """Fetch trade result, polling until it becomes available.
 
     Первоначально ждём ``wait_time`` секунд (время закрытия спринта),
     затем запрашиваем результат сделки. Если результат не получен, то
-    продолжаем проверять его с растущей задержкой, пока не достигнем
+    продолжаем проверять его с фиксированной задержкой, пока не достигнем
     ``max_attempts``. Короутина прерывается исключением
     ``asyncio.CancelledError`` или возвращает ``None``, если ответ так и
     не получен.
@@ -217,7 +216,7 @@ async def check_trade_result(
     payload = {"user_id": user_id, "user_hash": user_hash, "trade_id": trade_id}
 
     attempts = 0
-    poll_delay = max(0.0, initial_poll_delay)
+    poll_delay = min(max_poll_delay, max(0.0, initial_poll_delay))
 
     while attempts < max_attempts:
         try:
@@ -238,7 +237,6 @@ async def check_trade_result(
         attempts += 1
         # результат ещё не готов — подождём и попробуем снова
         await asyncio.sleep(poll_delay)
-        poll_delay = min(max_poll_delay, poll_delay * backoff_factor)
 
     return None
 

--- a/core/trade_result_queue.py
+++ b/core/trade_result_queue.py
@@ -75,7 +75,6 @@ class TradeResultQueue:
         wait_time: float = 60.0,
         max_attempts: int = 60,
         initial_poll_delay: float = 1.0,
-        backoff_factor: float = 1.5,
         max_poll_delay: float = 10.0,
     ) -> Optional[float]:
         """Поставить запрос проверки сделки в очередь."""
@@ -89,7 +88,6 @@ class TradeResultQueue:
                 wait_time=wait_time,
                 max_attempts=max_attempts,
                 initial_poll_delay=initial_poll_delay,
-                backoff_factor=backoff_factor,
                 max_poll_delay=max_poll_delay,
             )
         )


### PR DESCRIPTION
## Summary
- align async trade result polling with synchronous behavior by using a constant interval
- update trade result queue wrapper to match the simplified polling signature

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942218ea71c832e993551a832a97eb7)