### PR TITLE
Remove backoff when polling trade results

### DIFF
--- a/core/intrade_api_async.py
+++ b/core/intrade_api_async.py
@@ -199,17 +199,14 @@ async def check_trade_result(
     *,
     max_attempts: int = 60,
     initial_poll_delay: float = 1.0,
-    backoff_factor: float = 1.5,
-    max_poll_delay: float = 10.0,
 ) -> Optional[float]:
     """Fetch trade result, polling until it becomes available.
 
     Первоначально ждём ``wait_time`` секунд (время закрытия спринта),
     затем запрашиваем результат сделки. Если результат не получен, то
-    продолжаем проверять его с растущей задержкой, пока не достигнем
-    ``max_attempts``. Короутина прерывается исключением
-    ``asyncio.CancelledError`` или возвращает ``None``, если ответ так и
-    не получен.
+    продолжаем проверять его через фиксированный интервал, пока не
+    достигнем ``max_attempts``. Короутина прерывается исключением
+    ``asyncio.CancelledError`` или возвращает ``None``, если ответ так и не получен.
 
     Возвращает прибыль (``result - investment``) как ``float``.
     """
@@ -238,7 +235,6 @@ async def check_trade_result(
         attempts += 1
         # результат ещё не готов — подождём и попробуем снова
         await asyncio.sleep(poll_delay)
-        poll_delay = min(max_poll_delay, poll_delay * backoff_factor)
 
     return None
 

--- a/core/trade_result_queue.py
+++ b/core/trade_result_queue.py
@@ -75,8 +75,6 @@ class TradeResultQueue:
         wait_time: float = 60.0,
         max_attempts: int = 60,
         initial_poll_delay: float = 1.0,
-        backoff_factor: float = 1.5,
-        max_poll_delay: float = 10.0,
     ) -> Optional[float]:
         """Поставить запрос проверки сделки в очередь."""
 
@@ -89,8 +87,6 @@ class TradeResultQueue:
                 wait_time=wait_time,
                 max_attempts=max_attempts,
                 initial_poll_delay=initial_poll_delay,
-                backoff_factor=backoff_factor,
-                max_poll_delay=max_poll_delay,
             )
         )
 


### PR DESCRIPTION
## Summary
- stop increasing the polling delay when checking trade results so intervals stay constant
- adjust trade result queue helper to match the simplified check_trade_result signature
- refresh the trade result polling docstring to mention fixed intervals

## Testing
- python -m compileall core strategies

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69422564a63c832e93e33d7c6577ac37)