### PR TITLE
Keep constant poll interval without shortening wait window

### DIFF
--- a/core/trade_result_queue.py
+++ b/core/trade_result_queue.py
@@ -75,8 +75,7 @@ class TradeResultQueue:
         wait_time: float = 60.0,
         max_attempts: int = 60,
         initial_poll_delay: float = 1.0,
-        backoff_factor: float = 1.5,
-        max_poll_delay: float = 10.0,
+        poll_interval: float = 10.0,
     ) -> Optional[float]:
         """Поставить запрос проверки сделки в очередь."""
 
@@ -89,8 +88,7 @@ class TradeResultQueue:
                 wait_time=wait_time,
                 max_attempts=max_attempts,
                 initial_poll_delay=initial_poll_delay,
-                backoff_factor=backoff_factor,
-                max_poll_delay=max_poll_delay,
+                poll_interval=poll_interval,
             )
         )
 


### PR DESCRIPTION
## Summary
- keep constant polling but introduce a fixed interval after the first retry so the total wait window remains long enough
- update trade result queue wrapper to pass the new poll interval parameter
- clarify trade result polling docstring to describe the fixed-interval approach

## Testing
- python -m compileall core strategies

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69422564a63c832e93e33d7c6577ac37)